### PR TITLE
Added ability to bind epg to static fex port

### DIFF
--- a/plugins/modules/mso_schema_site_anp_epg_staticport.py
+++ b/plugins/modules/mso_schema_site_anp_epg_staticport.py
@@ -58,11 +58,6 @@ options:
     description:
     - The leaf of the static port.
     type: str
-  fex_port:
-    description:
-    - Indicate if the static port resides on a fex.
-    type: bool
-    default: no
   fex:
     description:
     - The fex id of the static port.
@@ -140,7 +135,6 @@ EXAMPLES = r'''
     type: port
     pod: pod-1
     leaf: 101
-    fex_port: yes
     fex: 151
     path: eth1/1
     vlan: 126
@@ -215,7 +209,6 @@ def main():
         type=dict(type='str', default='port', choices=['port']),
         pod=dict(type='str'),  # This parameter is not required for querying all objects
         leaf=dict(type='str'),  # This parameter is not required for querying all objects
-        fex_port=dict(type=bool, default=False),   # This parameter is not required for querying all objects
         fex=dict(type='str'),    # This parameter is not required for querying all objects
         path=dict(type='str'),  # This parameter is not required for querying all objects
         vlan=dict(type='int'),  # This parameter is not required for querying all objects
@@ -230,7 +223,6 @@ def main():
         required_if=[
             ['state', 'absent', ['type', 'pod', 'leaf', 'path', 'vlan']],
             ['state', 'present', ['type', 'pod', 'leaf', 'path', 'vlan']],
-            ['fex_port', 'true', ['type', 'pod', 'leaf', 'fex', 'path', 'vlan']],
         ],
     )
 
@@ -242,7 +234,6 @@ def main():
     path_type = module.params['type']
     pod = module.params['pod']
     leaf = module.params['leaf']
-    fex_port = module.params['fex_port']
     fex = module.params['fex']
     path = module.params['path']
     vlan = module.params['vlan']
@@ -250,8 +241,8 @@ def main():
     mode = module.params['mode']
     state = module.params['state']
 
-    if path_type == 'port' and fex_port is True:
-        # Select port path for fex if fex_port is true
+    if path_type == 'port' and fex is not None:
+        # Select port path for fex if fex param is used
         portpath = 'topology/{0}/paths-{1}/extpaths-{2}/pathep-[{3}]'.format(pod, leaf, fex, path)
     else:
         portpath = 'topology/{0}/paths-{1}/pathep-[{2}]'.format(pod, leaf, path)

--- a/plugins/modules/mso_schema_site_anp_epg_staticport.py
+++ b/plugins/modules/mso_schema_site_anp_epg_staticport.py
@@ -62,8 +62,8 @@ options:
     description:
     - Does the static port reside on a fex.
     type: bool
-    choices: [true, false]
-    default: false
+    choices: [True, False]
+    default: False
   fex:
     description:
     - The fex id of the static port.
@@ -216,7 +216,7 @@ def main():
         type=dict(type='str', default='port', choices=['port']),
         pod=dict(type='str'),  # This parameter is not required for querying all objects
         leaf=dict(type='str'),  # This parameter is not required for querying all objects
-        fex_port=dict(type='bool', default='false', choices=['true', 'false']),   # This parameter is not required for querying all objects
+        fex_port=dict(type='bool', default=False, choices=[True, False]),   # This parameter is not required for querying all objects
         fex=dict(type='str'),    # This parameter is not required for querying all objects
         path=dict(type='str'),  # This parameter is not required for querying all objects
         vlan=dict(type='int'),  # This parameter is not required for querying all objects

--- a/plugins/modules/mso_schema_site_anp_epg_staticport.py
+++ b/plugins/modules/mso_schema_site_anp_epg_staticport.py
@@ -60,13 +60,14 @@ options:
     type: str
   fex_port:
     description:
-    - The path of the static port exists on a connected fex.
-    type: str
+    - Does the static port reside on a fex.
+    type: bool
     choices: [true, false]
     default: false
   fex:
     description:
-    - The fex of the static port.
+    - The fex id of the static port.
+    type: str
   path:
     description:
     - The path of the static port.
@@ -215,7 +216,7 @@ def main():
         type=dict(type='str', default='port', choices=['port']),
         pod=dict(type='str'),  # This parameter is not required for querying all objects
         leaf=dict(type='str'),  # This parameter is not required for querying all objects
-        fex_port=dict(type='str', default='false', choices=['true', 'false']),   # This parameter is not required for querying all objects
+        fex_port=dict(type='bool', default='false', choices=['true', 'false']),   # This parameter is not required for querying all objects
         fex=dict(type='str'),    # This parameter is not required for querying all objects
         path=dict(type='str'),  # This parameter is not required for querying all objects
         vlan=dict(type='int'),  # This parameter is not required for querying all objects
@@ -230,7 +231,7 @@ def main():
         required_if=[
             ['state', 'absent', ['type', 'pod', 'leaf', 'path', 'vlan']],
             ['state', 'present', ['type', 'pod', 'leaf', 'path', 'vlan']],
-            ['fex_port', 'true', ['type', 'pod', 'leaf', 'fex', 'path', 'vlan']],        
+            ['fex_port', 'true', ['type', 'pod', 'leaf', 'fex', 'path', 'vlan']],
         ],
     )
 

--- a/plugins/modules/mso_schema_site_anp_epg_staticport.py
+++ b/plugins/modules/mso_schema_site_anp_epg_staticport.py
@@ -60,10 +60,9 @@ options:
     type: str
   fex_port:
     description:
-    - Does the static port reside on a fex.
+    - Indicate if the static port resides on a fex.
     type: bool
-    choices: [True, False]
-    default: False
+    default: no
   fex:
     description:
     - The fex id of the static port.
@@ -141,7 +140,7 @@ EXAMPLES = r'''
     type: port
     pod: pod-1
     leaf: 101
-    fex_port: true
+    fex_port: yes
     fex: 151
     path: eth1/1
     vlan: 126
@@ -216,7 +215,7 @@ def main():
         type=dict(type='str', default='port', choices=['port']),
         pod=dict(type='str'),  # This parameter is not required for querying all objects
         leaf=dict(type='str'),  # This parameter is not required for querying all objects
-        fex_port=dict(type='bool', default=False, choices=[True, False]),   # This parameter is not required for querying all objects
+        fex_port=dict(type=bool, default=False),   # This parameter is not required for querying all objects
         fex=dict(type='str'),    # This parameter is not required for querying all objects
         path=dict(type='str'),  # This parameter is not required for querying all objects
         vlan=dict(type='int'),  # This parameter is not required for querying all objects
@@ -251,7 +250,7 @@ def main():
     mode = module.params['mode']
     state = module.params['state']
 
-    if path_type == 'port' and fex_port == 'true':
+    if path_type == 'port' and fex_port is True:
         # Select port path for fex if fex_port is true
         portpath = 'topology/{0}/paths-{1}/extpaths-{2}/pathep-[{3}]'.format(pod, leaf, fex, path)
     else:

--- a/plugins/modules/mso_schema_site_anp_epg_staticport.py
+++ b/plugins/modules/mso_schema_site_anp_epg_staticport.py
@@ -58,6 +58,15 @@ options:
     description:
     - The leaf of the static port.
     type: str
+  fex_port:
+    description:
+    - The path of the static port exists on a connected fex.
+    type: str
+    choices: [true, false]
+    default: false
+  fex:
+    description:
+    - The fex of the static port.
   path:
     description:
     - The path of the static port.
@@ -115,6 +124,27 @@ EXAMPLES = r'''
     path: eth1/1
     vlan: 126
     deployment_immediacy: immediate
+    state: present
+  delegate_to: localhost
+
+- name: Add a new static fex port to a site EPG
+  mso_schema_site_anp_epg_staticport:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    schema: Schema1
+    site: Site1
+    template: Template1
+    anp: ANP1
+    epg: EPG1
+    type: port
+    pod: pod-1
+    leaf: 101
+    fex_port: true
+    fex: 151
+    path: eth1/1
+    vlan: 126
+    deployment_immediacy: lazy
     state: present
   delegate_to: localhost
 
@@ -185,6 +215,8 @@ def main():
         type=dict(type='str', default='port', choices=['port']),
         pod=dict(type='str'),  # This parameter is not required for querying all objects
         leaf=dict(type='str'),  # This parameter is not required for querying all objects
+        fex_port=dict(type='str', default='false', choices=['true', 'false']),   # This parameter is not required for querying all objects
+        fex=dict(type='str'),    # This parameter is not required for querying all objects
         path=dict(type='str'),  # This parameter is not required for querying all objects
         vlan=dict(type='int'),  # This parameter is not required for querying all objects
         deployment_immediacy=dict(type='str', choices=['immediate', 'lazy']),
@@ -198,6 +230,7 @@ def main():
         required_if=[
             ['state', 'absent', ['type', 'pod', 'leaf', 'path', 'vlan']],
             ['state', 'present', ['type', 'pod', 'leaf', 'path', 'vlan']],
+            ['fex_port', 'true', ['type', 'pod', 'leaf', 'fex', 'path', 'vlan']],        
         ],
     )
 
@@ -209,13 +242,18 @@ def main():
     path_type = module.params['type']
     pod = module.params['pod']
     leaf = module.params['leaf']
+    fex_port = module.params['fex_port']
+    fex = module.params['fex']
     path = module.params['path']
     vlan = module.params['vlan']
     deployment_immediacy = module.params['deployment_immediacy']
     mode = module.params['mode']
     state = module.params['state']
 
-    if path_type == 'port':
+    if path_type == 'port' and fex_port == 'true':
+        # Select port path for fex if fex_port is true
+        portpath = 'topology/{0}/paths-{1}/extpaths-{2}/pathep-[{3}]'.format(pod, leaf, fex, path)
+    else:
         portpath = 'topology/{0}/paths-{1}/pathep-[{2}]'.format(pod, leaf, path)
 
     mso = MSOModule(module)


### PR DESCRIPTION
**SUMMARY**
Added ability to configure static port bindings on a fex downstream of a leaf. Fex ports required a different static path.

**ISSUE TYPE**
Feature Pull Request

**ADDITIONAL INFORMATION**
Prior to this addition, the module is unable to configure fex ports because portpath was hard coded to a path specific to leaf ports only. Introducing new, optional fex fields and conditional now allows for fex ports to be configured if desired.

Tested with MSO: 3.0(1i) and ACI: 4.2(4i)