### PR TITLE
Remove label with test domain before create it

### DIFF
--- a/tests/integration/targets/mso_label/tasks/main.yml
+++ b/tests/integration/targets/mso_label/tasks/main.yml
@@ -42,6 +42,12 @@
     login_domain: Local
   register: nm_remove_label3
 
+- name: Remove label ansible_test4
+  mso_label:
+    <<: *domain_label_absent
+    label: ansible_test4
+    login_domain: test
+
 # ADD LABEL
 - name: Add label (check_mode)
   mso_label: &label_present


### PR DESCRIPTION
Fix small issue with cleanup of used objects introduced by the "adding support for login domain" pull request.

Closes #35 