### PR TITLE
Fix all tests to run with user "admin" and add "apic_site_id" as a variable for MSO Engineering pipeline

### DIFF
--- a/tests/integration/targets/mso_label/tasks/main.yml
+++ b/tests/integration/targets/mso_label/tasks/main.yml
@@ -46,7 +46,7 @@
   mso_label:
     <<: *domain_label_absent
     label: ansible_test4
-    login_domain: test
+    login_domain: '{{ mso_login_domain | default("test") }}'
 
 # ADD LABEL
 - name: Add label (check_mode)
@@ -328,7 +328,7 @@
   mso_label: 
     <<: *domain_label_present
     label: ansible_test4
-    login_domain: test
+    login_domain: '{{ mso_login_domain | default("test") }}'
   register: label_test_domain
 
 - name: Verify label_test_domain

--- a/tests/integration/targets/mso_schema_site_anp_epg_domain/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_domain/tasks/main.yml
@@ -28,7 +28,7 @@
     site: '{{ mso_site | default("ansible_test") }}'
     apic_username: '{{ apic_username }}'
     apic_password: '{{ apic_password }}'
-    apic_site_id: 101
+    apic_site_id: '{{ apic_site_id | default(101) }}'
     urls:
     - https://{{ apic_hostname }}
     state: present

--- a/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
@@ -28,7 +28,7 @@
     site: '{{ mso_site | default("ansible_test") }}'
     apic_username: '{{ apic_username }}'
     apic_password: '{{ apic_password }}'
-    apic_site_id: 101
+    apic_site_id: '{{ apic_site_id | default(101) }}'
     urls:
     - https://{{ apic_hostname }}
     state: present

--- a/tests/integration/targets/mso_schema_template_anp_epg/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_anp_epg/tasks/main.yml
@@ -24,7 +24,7 @@
 #     site: '{{ mso_site | default("ansible_test") }}'
 #     apic_username: '{{ apic_username }}'
 #     apic_password: '{{ apic_password }}'
-#     apic_site_id: 101
+#     apic_site_id: '{{ apic_site_id | default(101) }}'
 #     urls:
 #     - https://{{ apic_hostname }}
 #     state: present

--- a/tests/integration/targets/mso_schema_template_anp_epg/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_anp_epg/tasks/main.yml
@@ -40,7 +40,6 @@
     output_level: '{{ mso_output_level | default("info") }}'
     tenant: ansible_test
     users:
-    - admin
     - '{{ mso_username }}'
     # sites:
     # - '{{ mso_site | default("ansible_test") }}'

--- a/tests/integration/targets/mso_schema_template_anp_epg_contract/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_anp_epg_contract/tasks/main.yml
@@ -24,7 +24,7 @@
 #     site: '{{ mso_site | default("ansible_test") }}'
 #     apic_username: '{{ apic_username }}'
 #     apic_password: '{{ apic_password }}'
-#     apic_site_id: 101
+#     apic_site_id: '{{ apic_site_id | default(101) }}'
 #     urls:
 #     - https://{{ apic_hostname }}
 #     state: present

--- a/tests/integration/targets/mso_schema_template_anp_epg_contract/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_anp_epg_contract/tasks/main.yml
@@ -40,7 +40,6 @@
     output_level: '{{ mso_output_level | default("info") }}'
     tenant: ansible_test
     users:
-    - admin
     - '{{ mso_username }}'
     # sites:
     # - '{{ mso_site | default("ansible_test") }}'

--- a/tests/integration/targets/mso_schema_template_bd/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_bd/tasks/main.yml
@@ -40,7 +40,6 @@
     output_level: '{{ mso_output_level | default("info") }}'
     tenant: ansible_test
     users:
-    - admin
     - '{{ mso_username }}'
     sites:
     - '{{ mso_site | default("ansible_test") }}'

--- a/tests/integration/targets/mso_schema_template_bd/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_bd/tasks/main.yml
@@ -24,7 +24,7 @@
     site: '{{ mso_site | default("ansible_test") }}'
     apic_username: '{{ apic_username }}'
     apic_password: '{{ apic_password }}'
-    apic_site_id: 101
+    apic_site_id: '{{ apic_site_id | default(101) }}'
     urls:
     - https://{{ apic_hostname }}
     state: present

--- a/tests/integration/targets/mso_schema_template_contract_filter/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_contract_filter/tasks/main.yml
@@ -25,7 +25,7 @@
 #     site: '{{ mso_site | default("ansible_test") }}'
 #     apic_username: '{{ apic_username }}'
 #     apic_password: '{{ apic_password }}'
-#     apic_site_id: 101
+#     apic_site_id: '{{ apic_site_id | default(101) }}'
 #     urls:
 #     - https://{{ apic_hostname }}
 #     state: present

--- a/tests/integration/targets/mso_schema_template_contract_filter/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_contract_filter/tasks/main.yml
@@ -41,7 +41,6 @@
     output_level: '{{ mso_output_level | default("info") }}'
     tenant: ansible_test
     users:
-    - admin
     - '{{ mso_username }}'
     # sites:
     # - '{{ mso_site | default("ansible_test") }}'

--- a/tests/integration/targets/mso_schema_template_external_epg_contract/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_external_epg_contract/tasks/main.yml
@@ -24,7 +24,7 @@
 #     site: '{{ mso_site | default("ansible_test") }}'
 #     apic_username: '{{ apic_username }}'
 #     apic_password: '{{ apic_password }}'
-#     apic_site_id: 101
+#     apic_site_id: '{{ apic_site_id | default(101) }}'
 #     urls:
 #     - https://{{ apic_hostname }}
 #     state: present

--- a/tests/integration/targets/mso_schema_template_external_epg_contract/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_external_epg_contract/tasks/main.yml
@@ -40,7 +40,6 @@
     output_level: '{{ mso_output_level | default("info") }}'
     tenant: ansible_test
     users:
-    - admin
     - '{{ mso_username }}'
     # sites:
     # - '{{ mso_site | default("ansible_test") }}'

--- a/tests/integration/targets/mso_schema_template_externalepg/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_externalepg/tasks/main.yml
@@ -36,7 +36,7 @@
 #     site: '{{ mso_site | default("ansible_test") }}'
 #     apic_username: '{{ apic_username }}'
 #     apic_password: '{{ apic_password }}'
-#     apic_site_id: 101
+#     apic_site_id: '{{ apic_site_id | default(101) }}'
 #     urls:
 #     - https://{{ apic_hostname }}
 #     state: present

--- a/tests/integration/targets/mso_schema_template_vrf_contract/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_vrf_contract/tasks/main.yml
@@ -36,7 +36,7 @@
 #     site: '{{ mso_site | default("ansible_test") }}'
 #     apic_username: '{{ apic_username }}'
 #     apic_password: '{{ apic_password }}'
-#     apic_site_id: 101
+#     apic_site_id: '{{ apic_site_id | default(101) }}'
 #     urls:
 #     - https://{{ apic_hostname }}
 #     state: present

--- a/tests/integration/targets/mso_site/tasks/main.yml
+++ b/tests/integration/targets/mso_site/tasks/main.yml
@@ -116,7 +116,7 @@
     site: '{{ mso_site | default("ansible_test") }}'
     apic_username: '{{ apic_username }}'
     apic_password: '{{ apic_password }}'
-    apic_site_id: 101
+    apic_site_id: '{{ apic_site_id | default(101) }}'
     urls:
     - https://{{ apic_hostname }}
     location:
@@ -429,7 +429,7 @@
     site: '{{ mso_site | default("ansible_test") }}'
     apic_username: '{{ apic_username }}'
     apic_password: '{{ apic_password }}'
-    apic_site_id: 101
+    apic_site_id: '{{ apic_site_id | default(101) }}'
     urls:
     - https://{{ apic_hostname }}
     state: present

--- a/tests/integration/targets/mso_tenant/tasks/main.yml
+++ b/tests/integration/targets/mso_tenant/tasks/main.yml
@@ -177,7 +177,18 @@
   assert:
     that:
     - nm_add_tenant2 is changed
+
+- name: Verify nm_add_tenant2 (when mso_username != admin)
+  assert:
+    that:
     - nm_add_tenant2.current.userAssociations | length == 2
+  when: mso_username != 'admin'
+
+- name: Verify nm_add_tenant2 (when mso_username == admin)
+  assert:
+    that:
+    - nm_add_tenant2.current.userAssociations | length == 1
+  when: mso_username == 'admin'
 
 - name: Add tenant 2 again (normal mode)
   mso_tenant: 
@@ -193,7 +204,18 @@
   assert:
     that:
     - nm_add_tenant2_again is not changed
+
+- name: Verify nm_add_tenant2_again (when mso_username != admin)
+  assert:
+    that:
     - nm_add_tenant2_again.current.userAssociations | length == 2
+  when: mso_username != 'admin'
+
+- name: Verify nm_add_tenant2_again (when mso_username == admin)
+  assert:
+    that:
+    - nm_add_tenant2_again.current.userAssociations | length == 1
+  when: mso_username == 'admin'
 
 - name: Add tenant 3 with duplicate admin user (normal mode)
   mso_tenant: 
@@ -244,7 +266,18 @@
   assert:
     that:
     - nm_add_tenant3 is changed
+
+- name: Verify nm_add_tenant3 (when mso_username != admin)
+  assert:
+    that:
     - nm_add_tenant3.current.userAssociations | length == 2
+  when: mso_username != 'admin'
+
+- name: Verify nm_add_tenant3 (when mso_username == admin)
+  assert:
+    that:
+    - nm_add_tenant3.current.userAssociations | length == 1
+  when: mso_username == 'admin'
 
 # CHANGE TENANT
 - name: Change tenant (check_mode)

--- a/tests/integration/targets/mso_tenant/tasks/main.yml
+++ b/tests/integration/targets/mso_tenant/tasks/main.yml
@@ -235,7 +235,6 @@
     <<: *tenant_present
     tenant: ansible_test3
     users:
-    - admin
     - '{{ mso_username }}'
     display_name: null
     state: present


### PR DESCRIPTION
Add Site ID variable named apic_site_id to all tasks
Fix old definition of admin in tenant creation
Add support for "admin" as mso_username
Add mso_login_domain as a variable to tests

This resolves #58 and will allow MSO Engineering to run all the tests directly in their pipeline.