### PR TITLE
Fix mso_schema_site_vrf_region_cidr and add VGW attribute to mso_schema_site_vrf_region_cidr_subnet

### DIFF
--- a/plugins/modules/mso_schema_site_vrf_region_cidr.py
+++ b/plugins/modules/mso_schema_site_vrf_region_cidr.py
@@ -260,7 +260,9 @@ def main():
                 payload = new_cidr
 
     if state == 'query':
-        if region not in regions:
+        if vrf_ref not in vrfs:
+            mso.fail_json(msg="Provided vrf '{0}' does not exist at site level.".format(vrf))
+        elif not regions or region not in regions:
             mso.fail_json(msg="Provided region '{0}' does not exist. Existing regions: {1}".format(region, ', '.join(regions)))
         elif cidr is None and not payload:
             mso.existing = schema_obj.get('sites')[site_idx]['vrfs'][vrf_idx]['regions'][region_idx]['cidrs']

--- a/plugins/modules/mso_schema_site_vrf_region_cidr.py
+++ b/plugins/modules/mso_schema_site_vrf_region_cidr.py
@@ -55,6 +55,7 @@ options:
     description:
     - Whether this is the primary CIDR.
     type: bool
+    default: true
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.

--- a/plugins/modules/mso_schema_template_vrf.py
+++ b/plugins/modules/mso_schema_template_vrf.py
@@ -188,9 +188,7 @@ def main():
             name=vrf,
             displayName=display_name,
             l3MCast=layer3_multicast,
-            vzAnyEnabled=vzany,
-            # FIXME
-            regions=[],
+            vzAnyEnabled=vzany
         )
 
         mso.sanitize(payload, collate=True)

--- a/tests/integration/targets/mso_schema_site_anp_epg_domain/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_domain/tasks/main.yml
@@ -22,6 +22,15 @@
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("info") }}'
 
+- name: Remove Schemas
+  mso_schema:
+    <<: *mso_info
+    schema: item
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
 - name: Ensure site exists
   mso_site:
     <<: *mso_info
@@ -43,12 +52,6 @@
     - '{{ mso_site | default("ansible_test") }}'
     state: present
 
-- name: Remove Schemas
-  mso_schema:
-    <<: *mso_info
-    schema: '{{ mso_schema | default("ansible_test") }}'
-    state: absent
-      
 - name: Ensure schema 1 with Template 1 exists
   mso_schema_template: 
     <<: *mso_info

--- a/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
@@ -22,6 +22,15 @@
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("info") }}'
 
+- name: Remove Schemas
+  mso_schema:
+    <<: *mso_info
+    schema: item
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
 - name: Ensure site exists
   mso_site:
     <<: *mso_info
@@ -43,12 +52,6 @@
     - '{{ mso_site | default("ansible_test") }}'
     state: present
 
-- name: Remove Schemas
-  mso_schema:
-    <<: *mso_info
-    schema: '{{ mso_schema | default("ansible_test") }}'
-    state: absent
-      
 - name: Ensure schema 1 with Template 1 exists
   mso_schema_template: 
     <<: *mso_info

--- a/tests/integration/targets/mso_schema_site_vrf_region_cidr/aliases
+++ b/tests/integration/targets/mso_schema_site_vrf_region_cidr/aliases
@@ -1,0 +1,2 @@
+# No ACI MultiSite infrastructure, so not enabled
+# unsupported

--- a/tests/integration/targets/mso_schema_site_vrf_region_cidr/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf_region_cidr/tasks/main.yml
@@ -22,8 +22,20 @@
       use_ssl: '{{ mso_use_ssl | default(true) }}'
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("info") }}'
-    sites: "[ { 'site': 'aws_{{ mso_site | default(\"ansible_test\") }}', 'region': 'us-west-1', 'cidr': '10.0.0.0/16'}, 
-              { 'site': 'azure_{{ mso_site | default(\"ansible_test\") }}', 'region': 'westus', 'cidr': '10.1.0.0/16'}]"
+    sites: "['aws_{{ mso_site | default(\"ansible_test\") }}', 
+              'azure_{{ mso_site | default(\"ansible_test\") }}',
+              '{{ mso_site | default(\"ansible_test\") }}']"
+
+- name: Ensure site exists
+  mso_site:
+    <<: *mso_info
+    site: '{{ mso_site | default("ansible_test") }}'
+    apic_username: '{{ apic_username }}'
+    apic_password: '{{ apic_password }}'
+    apic_site_id: '{{ apic_site_id | default(101) }}'
+    urls:
+    - https://{{ apic_hostname }}
+    state: present
 
 - name: Ensure site exists
   mso_site:
@@ -50,7 +62,7 @@
 - name: Remove Schemas
   mso_schema:
     <<: *mso_info
-    schema: item
+    schema: '{{ item }}'
     state: absent
   loop:
   - '{{ mso_schema | default("ansible_test") }}_2'
@@ -60,6 +72,8 @@
   mso_tenant: 
     <<: *mso_info
     tenant: ansible_test
+    sites:
+    - '{{ mso_site | default("ansible_test") }}'
     users:
     - '{{ mso_username }}'
     state: present
@@ -102,7 +116,7 @@
   mso_schema_site:
     <<: *mso_info
     schema: '{{ mso_schema | default("ansible_test") }}'
-    site: '{{ item.site }}'
+    site: '{{ item }}'
     template: Template 1
     state: present
   loop: '{{ sites }}'
@@ -115,12 +129,21 @@
     vrf: VRF1
     state: present
 
-- name: Ensure VRF1 exists
+- name: Ensure VRF2 exists
   mso_schema_template_vrf: 
     <<: *mso_info
     schema: '{{ mso_schema | default("ansible_test") }}'
     template: Template 1
     vrf: VRF2
+    state: present
+
+- name: Ensure VRF1 exists at Site level for the physical site
+  mso_schema_site_vrf:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    site: '{{ mso_site | default("ansible_test") }}'
+    vrf: VRF1
     state: present
 
 # ADD SUBNET
@@ -403,6 +426,27 @@
     - nm_query_cidr_all_azure.current[0].primary == true
     - nm_query_cidr_all_azure.current[1].ip == '10.3.0.0/16'
     - nm_query_cidr_all_azure.current[1].primary == false
+
+- name: Query CIDR in VRF2 (not present a Site level) for AWS Site (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query_all
+    vrf: VRF2
+  ignore_errors: yes
+  register: nm_query_cidr_all_aws_2
+
+- name: Query CIDR in VRF1 (with VRF present a Site level) for Physical Site (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query_all
+    site: '{{ mso_site | default("ansible_test") }}'
+    vrf: VRF1
+  ignore_errors: yes
+  register: nm_query_cidr_all_aws_3
+
+- name: Verify nm_query_cidr_all_aws_2 and nm_query_cidr_all_aws_3
+  assert:
+    that:
+    - nm_query_cidr_all_aws_2.msg == "Provided vrf 'VRF2' does not exist at site level."
+    - nm_query_cidr_all_aws_3.msg == "Provided region 'us-west-1' does not exist. Existing regions{{':'}} "
 
 # REMOVE CIDR
 - name: Remove CIDR (check_mode)

--- a/tests/integration/targets/mso_schema_site_vrf_region_cidr/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf_region_cidr/tasks/main.yml
@@ -47,6 +47,15 @@
     - https://{{ azure_apic_hostname }}
     state: present
 
+- name: Remove Schemas
+  mso_schema:
+    <<: *mso_info
+    schema: item
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
 - name: Ensure tenant ansible_test exist
   mso_tenant: 
     <<: *mso_info
@@ -73,12 +82,6 @@
     cloud_account: uni/tn-ansible_test/act-[9]-vendor-azure
     state: present
 
-- name: Remove Schemas
-  mso_schema:
-    <<: *mso_info
-    schema: '{{ mso_schema | default("ansible_test") }}'
-    state: absent
-      
 - name: Ensure schema 1 with Template 1 exists
   mso_schema_template: 
     <<: *mso_info

--- a/tests/integration/targets/mso_schema_site_vrf_region_cidr/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf_region_cidr/tasks/main.yml
@@ -1,0 +1,622 @@
+# Test code for the MSO modules
+# Copyright: (c) 2020, Lionel Hercot (@lhercot) <lhercot@cisco.com>
+# Copyright: (c) 2020, Shreyas Srish (@shrsr) <ssrish@cisco.com> (based on mso_schema_anp_epg_domain)
+# Copyright: (c) 2018, Dag Wieers (@dagwieers) <dag@wieers.com> (based on mso_site test case)
+
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI MultiSite host, username and password
+  fail:
+    msg: 'Please define the following variables: mso_hostname, mso_username and mso_password.'
+  when: mso_hostname is not defined or mso_username is not defined or mso_password is not defined
+
+# CLEAN ENVIRONMENT
+- name: Set vars
+  set_fact: 
+    mso_info: &mso_info
+      host: '{{ mso_hostname }}'
+      username: '{{ mso_username }}'
+      password: '{{ mso_password }}'
+      validate_certs: '{{ mso_validate_certs | default(false) }}'
+      use_ssl: '{{ mso_use_ssl | default(true) }}'
+      use_proxy: '{{ mso_use_proxy | default(true) }}'
+      output_level: '{{ mso_output_level | default("info") }}'
+    sites: "[ { 'site': 'aws_{{ mso_site | default(\'ansible_test\') }}', 'region': 'us-west-1', 'cidr': '10.0.0.0/16'}, 
+              { 'site': 'azure_{{ mso_site | default(\'ansible_test\') }}', 'region': 'westus', 'cidr': '10.1.0.0/16'}]"
+
+- name: Ensure site exists
+  mso_site:
+    <<: *mso_info
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    apic_username: '{{ aws_apic_username }}'
+    apic_password: '{{ aws_apic_password }}'
+    apic_site_id: '{{ aws_site_id | default(102) }}'
+    urls:
+    - https://{{ aws_apic_hostname }}
+    state: present
+
+- name: Ensure site exists
+  mso_site:
+    <<: *mso_info
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    apic_username: '{{ azure_apic_username }}'
+    apic_password: '{{ azure_apic_password }}'
+    apic_site_id: '{{ azure_site_id | default(103) }}'
+    urls:
+    - https://{{ azure_apic_hostname }}
+    state: present
+
+- name: Ensure tenant ansible_test exist
+  mso_tenant: 
+    <<: *mso_info
+    tenant: ansible_test
+    users:
+    - '{{ mso_username }}'
+    state: present
+
+- name: Ensure AWS site is present under tenant ansible_test
+  mso_tenant_site: 
+    <<: *mso_info
+    tenant: ansible_test
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    cloud_account: '000000000000'
+    aws_access_key: 1
+    secret_key: 0
+    state: present
+
+- name: Ensure Azure site is present under tenant ansible_test
+  mso_tenant_site: 
+    <<: *mso_info
+    tenant: ansible_test
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    cloud_account: uni/tn-ansible_test/act-[9]-vendor-azure
+    state: present
+
+- name: Remove Schemas
+  mso_schema:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    state: absent
+      
+- name: Ensure schema 1 with Template 1 exists
+  mso_schema_template: 
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    tenant: ansible_test
+    template: Template 1
+    state: present
+
+- name: Ensure schema 1 with Template 2 exists
+  mso_schema_template:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    tenant: ansible_test
+    template: Template 2
+    state: present
+
+- name: Add a new sites to a Template 1
+  mso_schema_site:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ item.site }}'
+    template: Template 1
+    state: present
+  loop: '{{ sites }}'
+
+- name: Ensure VRF1 exists
+  mso_schema_template_vrf: 
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    vrf: VRF1
+    state: present
+
+- name: Ensure VRF1 exists
+  mso_schema_template_vrf: 
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    vrf: VRF2
+    state: present
+
+# ADD SUBNET
+- name: Add a new CIDR in VRF1 at AWS site level (check mode)
+  mso_schema_site_vrf_region_cidr: &mso_present
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    vrf: VRF1
+    region: us-west-1
+    cidr: 10.0.0.0/16
+    primary: true
+    state: present
+  check_mode: yes
+  register: cm_add_cidr
+
+- name: Verify cm_add_cidr
+  assert:
+    that:
+    - cm_add_cidr is changed
+    - cm_add_cidr.previous == {}
+    - cm_add_cidr.current.ip == '10.0.0.0/16'
+    - cm_add_cidr.current.primary == true
+
+- name: Add a new CIDR in VRF1 at AWS site level (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_present
+  register: nm_add_cidr
+
+- name: Verify nm_add_cidr
+  assert:
+    that:
+    - nm_add_cidr is changed
+    - nm_add_cidr.previous == {}
+    - nm_add_cidr.current.ip == '10.0.0.0/16'
+    - nm_add_cidr.current.primary == true
+
+- name: Add same CIDR in VRF1 at AWS site level (check mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_present
+  register: cm_add_cidr_again
+
+- name: Verify cm_add_cidr_again
+  assert:
+    that:
+    - cm_add_cidr_again is not changed
+    - cm_add_cidr_again.current.ip == cm_add_cidr_again.previous.ip == '10.0.0.0/16'
+    - cm_add_cidr_again.current.primary == cm_add_cidr_again.previous.primary == true
+
+- name: Add same CIDR in VRF1 at AWS site level (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_present
+  register: nm_add_cidr_again
+
+- name: Verify nm_add_cidr_again
+  assert:
+    that:
+    - nm_add_cidr_again is not changed
+    - nm_add_cidr_again.current.ip == nm_add_cidr_again.previous.ip == '10.0.0.0/16'
+    - nm_add_cidr_again.current.primary == nm_add_cidr_again.previous.primary == true
+
+- name: Add a CIDR in VRF1 at Azure site level (check mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_present
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    region: westus
+    cidr: 10.1.0.0/16
+    primary: true
+  check_mode: yes
+  register: cm_add_cidr_2
+
+- name: Verify cm_add_cidr_2
+  assert:
+    that:
+    - cm_add_cidr_2 is changed
+    - cm_add_cidr_2.previous == {}
+    - cm_add_cidr_2.current.ip == '10.1.0.0/16'
+    - cm_add_cidr_2.current.primary == true
+
+- name: Add a CIDR in VRF1 at Azure site level (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_present
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    region: westus
+    cidr: 10.1.0.0/16
+    primary: true
+  register: nm_add_cidr_2
+
+- name: Verify nm_add_cidr_2
+  assert:
+    that:
+    - nm_add_cidr_2 is changed
+    - nm_add_cidr_2.previous == {}
+    - nm_add_cidr_2.current.ip == '10.1.0.0/16'
+    - nm_add_cidr_2.current.primary == true
+
+- name: Add a second CIDR in VRF1 at AWS site level (check mode)
+  mso_schema_site_vrf_region_cidr: &mso_present_2
+    <<: *mso_present
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    region: us-west-1
+    cidr: 10.2.0.0/16
+    primary: false
+  check_mode: yes
+  register: cm_add_cidr_3
+
+- name: Verify cm_add_cidr_3
+  assert:
+    that:
+    - cm_add_cidr_3 is changed
+    - cm_add_cidr_3.previous == {}
+    - cm_add_cidr_3.current.ip == '10.2.0.0/16'
+    - cm_add_cidr_3.current.primary == false
+
+- name: Add a second CIDR in VRF1 at AWS site level (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_present_2
+  register: nm_add_cidr_3
+
+- name: Verify nm_add_cidr_3
+  assert:
+    that:
+    - nm_add_cidr_3 is changed
+    - nm_add_cidr_3.previous == {}
+    - nm_add_cidr_3.current.ip == '10.2.0.0/16'
+    - nm_add_cidr_3.current.primary == false
+
+- name: Add a second CIDR in VRF1 at Azure site level (check mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_present
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    region: westus
+    cidr: 10.3.0.0/16
+    primary: false
+  check_mode: yes
+  register: cm_add_cidr_4
+
+- name: Verify cm_add_cidr_4
+  assert:
+    that:
+    - cm_add_cidr_4 is changed
+    - cm_add_cidr_4.previous == {}
+    - cm_add_cidr_4.current.ip == '10.3.0.0/16'
+    - cm_add_cidr_4.current.primary == false
+
+- name: Add a second CIDR in VRF1 at Azure site level (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_present
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    region: westus
+    cidr: 10.3.0.0/16
+    primary: false
+  register: nm_add_cidr_4
+
+- name: Verify nm_add_cidr_4
+  assert:
+    that:
+    - nm_add_cidr_4 is changed
+    - nm_add_cidr_4.previous == {}
+    - nm_add_cidr_4.current.ip == '10.3.0.0/16'
+    - nm_add_cidr_4.current.primary == false
+
+# QUERY CIDR
+- name: Query CIDR in VRF1 at AWS site level (check mode)
+  mso_schema_site_vrf_region_cidr: &mso_query
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    vrf: VRF1
+    region: us-west-1
+    cidr: 10.0.0.0/16
+    state: query
+  check_mode: yes
+  register: cm_query_cidr
+
+- name: Verify cm_query_cidr
+  assert:
+    that:
+    - cm_query_cidr is not changed
+    - cm_query_cidr.current.ip == '10.0.0.0/16'
+    - cm_query_cidr.current.primary == true
+
+- name: Query CIDR in VRF1 at AWS site level (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+  register: nm_query_cidr
+
+- name: Query CIDR in VRF1 at Azure site level (check mode)
+  mso_schema_site_vrf_region_cidr: &mso_query_2
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    vrf: VRF1
+    region: westus
+    cidr: 10.1.0.0/16
+    state: query
+  check_mode: yes
+  register: cm_query_cidr_2
+
+- name: Verify cm_query_cidr_2
+  assert:
+    that:
+    - cm_query_cidr_2 is not changed
+    - cm_query_cidr_2.current.ip == '10.1.0.0/16'
+    - cm_query_cidr_2.current.primary == true
+
+- name: Query CIDR in VRF1 at Azure site level (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query_2
+  register: nm_query_cidr_2
+
+- name: Verify nm_query_cidr_2
+  assert:
+    that:
+    - nm_query_cidr_2 is not changed
+    - nm_query_cidr_2.current.ip == '10.1.0.0/16'
+    - nm_query_cidr_2.current.primary == true
+
+# QUERY ALL CIDR
+- name: Query all CIDR in VRF1 at AWS site level (check mode)
+  mso_schema_site_vrf_region_cidr: &mso_query_all
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    vrf: VRF1
+    region: us-west-1
+    state: query
+  check_mode: yes
+  register: cm_query_cidr_all_aws
+
+- name: Query CIDR in VRF1 at Azure site level (check mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query_all
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    region: westus
+    state: query
+  check_mode: yes
+  register: cm_query_cidr_all_azure
+
+- name: Verify cm_query_cidr_all_aws and cm_query_cidr_all_azure
+  assert:
+    that:
+    - cm_query_cidr_all_aws is not changed
+    - cm_query_cidr_all_aws.current[0].ip == '10.0.0.0/16'
+    - cm_query_cidr_all_aws.current[0].primary == true
+    - cm_query_cidr_all_aws.current[1].ip == '10.2.0.0/16'
+    - cm_query_cidr_all_aws.current[1].primary == false
+    - cm_query_cidr_all_azure is not changed
+    - cm_query_cidr_all_azure.current[0].ip == '10.1.0.0/16'
+    - cm_query_cidr_all_azure.current[0].primary == true
+    - cm_query_cidr_all_azure.current[1].ip == '10.3.0.0/16'
+    - cm_query_cidr_all_azure.current[1].primary == false
+
+- name: Query CIDR in VRF1 at AWS site level (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query_all
+  register: nm_query_cidr_all_aws
+
+- name: Query CIDR in VRF1 at Azure site level (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query_all
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    region: westus
+  register: nm_query_cidr_all_azure
+
+- name: Verify nm_query_cidr_all_aws and nm_query_cidr_all_azure
+  assert:
+    that:
+    - nm_query_cidr_all_aws is not changed
+    - nm_query_cidr_all_aws.current[0].ip == '10.0.0.0/16'
+    - nm_query_cidr_all_aws.current[0].primary == true
+    - nm_query_cidr_all_aws.current[1].ip == '10.2.0.0/16'
+    - nm_query_cidr_all_aws.current[1].primary == false
+    - nm_query_cidr_all_azure is not changed
+    - nm_query_cidr_all_azure.current[0].ip == '10.1.0.0/16'
+    - nm_query_cidr_all_azure.current[0].primary == true
+    - nm_query_cidr_all_azure.current[1].ip == '10.3.0.0/16'
+    - nm_query_cidr_all_azure.current[1].primary == false
+
+# REMOVE CIDR
+- name: Remove CIDR (check_mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_present_2
+    state: absent
+  check_mode: yes
+  register: cm_remove_cidr
+
+- name: Verify cm_remove_cidr
+  assert:
+    that:
+    - cm_remove_cidr is changed
+    - cm_remove_cidr.current == {}
+
+- name: Remove CIDR (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_present_2
+    state: absent
+  register: nm_remove_cidr
+
+- name: Verify nm_remove_cidr
+  assert:
+    that:
+    - nm_remove_cidr is changed
+    - nm_remove_cidr.current == {}
+
+- name: Remove CIDR again (check_mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_present_2
+    state: absent
+  check_mode: yes
+  register: cm_remove_cidr_again
+
+- name: Verify cm_remove_cidr_again
+  assert:
+    that:
+    - cm_remove_cidr_again is not changed
+    - cm_remove_cidr_again.current == {}
+
+- name: Remove CIDR again (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_present_2
+    state: absent
+  register: nm_remove_cidr_again
+
+- name: Verify nm_remove_cidr_again
+  assert:
+    that:
+    - nm_remove_cidr_again is not changed
+    - nm_remove_cidr_again.current == {}
+
+# QUERY NON-EXISTING CIDR
+- name: Query non-existing CIDR (check_mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+    cidr: non_existing_cidr
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_query_non_cidr
+
+- name: Query non-existing CIDR (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+    cidr: non_existing_cidr
+  ignore_errors: yes
+  register: nm_query_non_cidr
+
+- name: Verify query_non_cidr
+  assert:
+    that:
+    - cm_query_non_cidr is not changed
+    - nm_query_non_cidr is not changed
+    - cm_query_non_cidr == nm_query_non_cidr
+    - cm_query_non_cidr.msg == nm_query_non_cidr.msg == "CIDR IP 'non_existing_cidr' not found"
+
+# QUERY NON-EXISTING region
+- name: Query non-existing region (check_mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+    region: non_existing_region
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_query_non_region
+
+- name: Query non-existing region (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+    region: non_existing_region
+  ignore_errors: yes
+  register: nm_query_non_region
+
+- name: Verify query_non_region
+  assert:
+    that:
+    - cm_query_non_region is not changed
+    - nm_query_non_region is not changed
+    - cm_query_non_region == nm_query_non_region
+    - cm_query_non_region.msg == nm_query_non_region.msg == "Provided region 'non_existing_region' does not exist. Existing regions{{':'}} us-west-1"
+
+# QUERY NON-EXISTING VRF
+- name: Query non-existing VRF (check_mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+    vrf: non_existing_vrf
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_query_non_vrf
+
+- name: Query non-existing VRF (normal mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+    vrf: non_existing_vrf
+  ignore_errors: yes
+  register: nm_query_non_vrf
+
+- name: Verify query_non_vrf
+  assert:
+    that:
+    - cm_query_non_vrf is not changed
+    - nm_query_non_vrf is not changed
+    - cm_query_non_vrf == nm_query_non_vrf
+    - cm_query_non_vrf.msg == nm_query_non_vrf.msg == "Provided vrf 'non_existing_vrf' does not exist. Existing vrfs{{':'}} VRF1, VRF2"
+
+# USE A NON-EXISTING STATE
+- name: Non-existing state for site cidr (check_mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+    state: non-existing-state
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_non_existing_state
+
+- name: Non-existing state for site cidr (normal_mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+    state: non-existing-state
+  ignore_errors: yes
+  register: nm_non_existing_state
+
+- name: Verify non_existing_state
+  assert:
+    that:
+    - cm_non_existing_state is not changed
+    - nm_non_existing_state is not changed
+    - cm_non_existing_state == nm_non_existing_state
+    - cm_non_existing_state.msg == nm_non_existing_state.msg == "value of state must be one of{{':'}} absent, present, query, got{{':'}} non-existing-state"
+
+# USE A NON-EXISTING SCHEMA
+- name: Non-existing schema for site cidr (check_mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+    schema: non-existing-schema
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_non_existing_schema
+
+- name: Non-existing schema for site cidr (normal_mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+    schema: non-existing-schema
+  ignore_errors: yes
+  register: nm_non_existing_schema
+
+- name: Verify non_existing_schema
+  assert:
+    that:
+    - cm_non_existing_schema is not changed
+    - nm_non_existing_schema is not changed
+    - cm_non_existing_schema == nm_non_existing_schema
+    - cm_non_existing_schema.msg == nm_non_existing_schema.msg == "Provided schema 'non-existing-schema' does not exist"
+
+# USE A NON-EXISTING TEMPLATE
+- name: Non-existing template for site cidr (check_mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+    template: non-existing-template
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_non_existing_template
+
+- name: Non-existing template for site cidr (normal_mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+    template: non-existing-template
+  ignore_errors: yes
+  register: nm_non_existing_template
+
+- name: Verify non_existing_template
+  assert:
+    that:
+    - cm_non_existing_template is not changed
+    - nm_non_existing_template is not changed
+    - cm_non_existing_template == nm_non_existing_template
+    - cm_non_existing_template.msg == nm_non_existing_template.msg == "Provided template 'non-existing-template' does not exist. Existing templates{{':'}} Template 1, Template 2"
+
+# USE A NON-ASSOCIATED TEMPLATE
+- name: Non-associated template for site cidr (check_mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+    template: Template 2
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_non_associated_template
+
+- name: Non-associated template for site cidr (normal_mode)
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_query
+    template: Template 2
+  ignore_errors: yes
+  register: nm_non_associated_template
+
+- name: Verify non_associated_template
+  assert:
+    that:
+    - cm_non_associated_template is not changed
+    - nm_non_associated_template is not changed
+    - cm_non_associated_template == nm_non_associated_template
+    - cm_non_associated_template.msg is match("Provided site/siteId/template 'aws_ansible_test/[0-9a-zA-Z]*/Template 2' does not exist. Existing siteIds/templates{{':'}} [0-9a-zA-Z]*/Template 1")
+    - nm_non_associated_template.msg is match("Provided site/siteId/template 'aws_ansible_test/[0-9a-zA-Z]*/Template 2' does not exist. Existing siteIds/templates{{':'}} [0-9a-zA-Z]*/Template 1")

--- a/tests/integration/targets/mso_schema_site_vrf_region_cidr/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf_region_cidr/tasks/main.yml
@@ -22,8 +22,8 @@
       use_ssl: '{{ mso_use_ssl | default(true) }}'
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("info") }}'
-    sites: "[ { 'site': 'aws_{{ mso_site | default(\'ansible_test\') }}', 'region': 'us-west-1', 'cidr': '10.0.0.0/16'}, 
-              { 'site': 'azure_{{ mso_site | default(\'ansible_test\') }}', 'region': 'westus', 'cidr': '10.1.0.0/16'}]"
+    sites: "[ { 'site': 'aws_{{ mso_site | default(\"ansible_test\") }}', 'region': 'us-west-1', 'cidr': '10.0.0.0/16'}, 
+              { 'site': 'azure_{{ mso_site | default(\"ansible_test\") }}', 'region': 'westus', 'cidr': '10.1.0.0/16'}]"
 
 - name: Ensure site exists
   mso_site:

--- a/tests/integration/targets/mso_schema_site_vrf_region_cidr_subnet/aliases
+++ b/tests/integration/targets/mso_schema_site_vrf_region_cidr_subnet/aliases
@@ -1,0 +1,2 @@
+# No ACI MultiSite infrastructure, so not enabled
+# unsupported

--- a/tests/integration/targets/mso_schema_site_vrf_region_cidr_subnet/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf_region_cidr_subnet/tasks/main.yml
@@ -1,0 +1,611 @@
+# Test code for the MSO modules
+# Copyright: (c) 2020, Lionel Hercot (@lhercot) <lhercot@cisco.com>
+# Copyright: (c) 2020, Shreyas Srish (@shrsr) <ssrish@cisco.com> (based on mso_schema_anp_epg_domain)
+# Copyright: (c) 2018, Dag Wieers (@dagwieers) <dag@wieers.com> (based on mso_site test case)
+
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI MultiSite host, username and password
+  fail:
+    msg: 'Please define the following variables: mso_hostname, mso_username and mso_password.'
+  when: mso_hostname is not defined or mso_username is not defined or mso_password is not defined
+
+# CLEAN ENVIRONMENT
+- name: Set vars
+  set_fact: 
+    mso_info: &mso_info
+      host: '{{ mso_hostname }}'
+      username: '{{ mso_username }}'
+      password: '{{ mso_password }}'
+      validate_certs: '{{ mso_validate_certs | default(false) }}'
+      use_ssl: '{{ mso_use_ssl | default(true) }}'
+      use_proxy: '{{ mso_use_proxy | default(true) }}'
+      output_level: '{{ mso_output_level | default("info") }}'
+    sites: "[ { 'site': 'aws_{{ mso_site | default(\'ansible_test\') }}', 'region': 'us-west-1', 'cidr': '10.0.0.0/16'}, 
+              { 'site': 'azure_{{ mso_site | default(\'ansible_test\') }}', 'region': 'westus', 'cidr': '10.1.0.0/16'}]"
+
+- name: Ensure site exists
+  mso_site:
+    <<: *mso_info
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    apic_username: '{{ aws_apic_username }}'
+    apic_password: '{{ aws_apic_password }}'
+    apic_site_id: '{{ aws_site_id | default(102) }}'
+    urls:
+    - https://{{ aws_apic_hostname }}
+    state: present
+
+- name: Ensure site exists
+  mso_site:
+    <<: *mso_info
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    apic_username: '{{ azure_apic_username }}'
+    apic_password: '{{ azure_apic_password }}'
+    apic_site_id: '{{ azure_site_id | default(103) }}'
+    urls:
+    - https://{{ azure_apic_hostname }}
+    state: present
+
+- name: Ensure tenant ansible_test exist
+  mso_tenant: 
+    <<: *mso_info
+    tenant: ansible_test
+    users:
+    - '{{ mso_username }}'
+    state: present
+
+- name: Ensure AWS site is present under tenant ansible_test
+  mso_tenant_site: 
+    <<: *mso_info
+    tenant: ansible_test
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    cloud_account: '000000000000'
+    aws_access_key: 1
+    secret_key: 0
+    state: present
+
+- name: Ensure Azure site is present under tenant ansible_test
+  mso_tenant_site: 
+    <<: *mso_info
+    tenant: ansible_test
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    cloud_account: uni/tn-ansible_test/act-[9]-vendor-azure
+    state: present
+
+- name: Remove Schemas
+  mso_schema:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    state: absent
+      
+- name: Ensure schema 1 with Template 1 exists
+  mso_schema_template: 
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    tenant: ansible_test
+    template: Template 1
+    state: present
+
+- name: Ensure schema 1 with Template 2 exists
+  mso_schema_template:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    tenant: ansible_test
+    template: Template 2
+    state: present
+
+- name: Add a new sites to a Template 1
+  mso_schema_site:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ item.site }}'
+    template: Template 1
+    state: present
+  loop: '{{ sites }}'
+
+- name: Ensure VRF1 exists
+  mso_schema_template_vrf: 
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    vrf: VRF1
+    state: present
+
+- name: Ensure VRF1 exists
+  mso_schema_template_vrf: 
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    vrf: VRF2
+    state: present
+
+- name: Ensure region for VRF1 at site level exists
+  mso_schema_site_vrf_region_cidr:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    site: '{{ item.site }}'
+    vrf: VRF1
+    region: '{{ item.region }}'
+    cidr: '{{ item.cidr }}'
+    state: present
+  loop: '{{ sites }}'
+
+# ADD SUBNET
+- name: Add a new subnet to AWS CIDR in VRF1 at site level (check mode)
+  mso_schema_site_vrf_region_cidr_subnet: &mso_present
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    vrf: VRF1
+    region: us-west-1
+    cidr: 10.0.0.0/16
+    subnet: 10.0.0.0/24
+    zone: us-west-1a
+    state: present
+  check_mode: yes
+  register: cm_add_subnet
+
+- name: Verify cm_add_subnet
+  assert:
+    that:
+    - cm_add_subnet is changed
+    - cm_add_subnet.previous == {}
+    - cm_add_subnet.current.ip == '10.0.0.0/24'
+    - cm_add_subnet.current.zone == 'us-west-1a'
+
+- name: Add a new subnet to AWS CIDR in VRF1 at site level (normal mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_present
+  register: nm_add_subnet
+
+- name: Verify nm_add_subnet
+  assert:
+    that:
+    - nm_add_subnet is changed
+    - nm_add_subnet.previous == {}
+    - nm_add_subnet.current.ip == '10.0.0.0/24'
+    - nm_add_subnet.current.zone == 'us-west-1a'
+
+- name: Add same subnet again to AWS CIDR in VRF1 at site level (check mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_present
+  register: cm_add_subnet_again
+
+- name: Verify cm_add_subnet_again
+  assert:
+    that:
+    - cm_add_subnet_again is not changed
+    - cm_add_subnet_again.current.ip == cm_add_subnet_again.previous.ip == '10.0.0.0/24'
+    - cm_add_subnet_again.current.zone == cm_add_subnet_again.previous.zone == 'us-west-1a'
+
+- name: Add same subnet again to AWS CIDR in VRF1 at site level (normal mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_present
+  register: nm_add_subnet_again
+
+- name: Verify nm_add_subnet_again
+  assert:
+    that:
+    - nm_add_subnet_again is not changed
+    - nm_add_subnet_again.current.ip == nm_add_subnet_again.previous.ip == '10.0.0.0/24'
+    - nm_add_subnet_again.current.zone == nm_add_subnet_again.previous.zone == 'us-west-1a'
+
+- name: Add a new subnet to Azure CIDR in VRF1 at site level (check mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_present
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    region: westus
+    cidr: 10.1.0.0/16
+    subnet: 10.1.0.0/24
+    zone: null
+  check_mode: yes
+  register: cm_add_subnet_2
+
+- name: Verify cm_add_subnet_2
+  assert:
+    that:
+    - cm_add_subnet_2 is changed
+    - cm_add_subnet_2.previous == {}
+    - cm_add_subnet_2.current.ip == '10.1.0.0/24'
+    - cm_add_subnet_2.current.zone == ''
+
+- name: Add a new subnet to Azure CIDR in VRF1 at site level (normal mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_present
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    region: westus
+    cidr: 10.1.0.0/16
+    subnet: 10.1.0.0/24
+    zone: null
+  register: nm_add_subnet_2
+
+- name: Verify nm_add_subnet_2
+  assert:
+    that:
+    - nm_add_subnet_2 is changed
+    - nm_add_subnet_2.previous == {}
+    - nm_add_subnet_2.current.ip == '10.1.0.0/24'
+    - nm_add_subnet_2.current.zone == ''
+
+- name: Add a second subnet to Azure CIDR in VRF1 at site level for VGW (check mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_present
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    region: westus
+    cidr: 10.1.0.0/16
+    subnet: 10.1.1.0/24
+    zone: null
+    vgw: true
+  check_mode: yes
+  register: cm_add_subnet_3
+
+- name: Verify cm_add_subnet_3
+  assert:
+    that:
+    - cm_add_subnet_3 is changed
+    - cm_add_subnet_3.previous == {}
+    - cm_add_subnet_3.current.ip == '10.1.1.0/24'
+    - cm_add_subnet_3.current.zone == ''
+    - cm_add_subnet_3.current.usage == 'gateway'
+
+- name: Add a second subnet to Azure CIDR in VRF1 at site level for VGW (normal mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_present
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    region: westus
+    cidr: 10.1.0.0/16
+    subnet: 10.1.1.0/24
+    zone: null
+    vgw: true
+  register: nm_add_subnet_3
+
+- name: Verify nm_add_subnet_3
+  assert:
+    that:
+    - nm_add_subnet_3 is changed
+    - nm_add_subnet_3.previous == {}
+    - nm_add_subnet_3.current.ip == '10.1.1.0/24'
+    - nm_add_subnet_3.current.zone == ''
+    - nm_add_subnet_3.current.usage == 'gateway'
+
+# QUERY SUBNETS
+- name: Query subnet to AWS CIDR in VRF1 at site level (check mode)
+  mso_schema_site_vrf_region_cidr_subnet: &mso_query
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    vrf: VRF1
+    region: us-west-1
+    cidr: 10.0.0.0/16
+    subnet: 10.0.0.0/24
+    state: query
+  check_mode: yes
+  register: cm_query_subnet
+
+- name: Verify cm_query_subnet
+  assert:
+    that:
+    - cm_query_subnet is not changed
+    - cm_query_subnet.current.ip == '10.0.0.0/24'
+    - cm_query_subnet.current.zone == 'us-west-1a'
+
+- name: Query subnet to AWS CIDR in VRF1 at site level (normal mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+  register: nm_query_subnet
+
+- name: Verify nm_query_subnet
+  assert:
+    that:
+    - nm_query_subnet is not changed
+
+# QUERY ALL SUBNETS
+- name: Query all subnets to AWS CIDR in VRF1 at site level (check mode)
+  mso_schema_site_vrf_region_cidr_subnet: &mso_query_all
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    vrf: VRF1
+    region: us-west-1
+    cidr: 10.0.0.0/16
+    state: query
+  check_mode: yes
+  register: cm_query_subnet_all_aws
+
+- name: Query all subnets to Azure CIDR in VRF1 at site level (check mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query_all
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    region: westus
+    cidr: 10.1.0.0/16
+    state: query
+  check_mode: yes
+  register: cm_query_subnet_all_azure
+
+- name: Verify cm_query_subnet_all_aws and cm_query_subnet_all_azure
+  assert:
+    that:
+    - cm_query_subnet_all_aws is not changed
+    - cm_query_subnet_all_aws.current[0].ip == '10.0.0.0/24'
+    - cm_query_subnet_all_aws.current[0].zone == 'us-west-1a'
+    - cm_query_subnet_all_azure is not changed
+    - cm_query_subnet_all_azure.current[0].ip == '10.1.0.0/24'
+    - cm_query_subnet_all_azure.current[0].zone == ''
+    - cm_query_subnet_all_azure.current[1].ip == '10.1.1.0/24'
+    - cm_query_subnet_all_azure.current[1].zone == ''
+
+- name: Query subnet to AWS CIDR in VRF1 at site level (normal mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query_all
+  register: nm_query_subnet_all_aws
+
+- name: Query subnet to AWS CIDR in VRF1 at site level (normal mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query_all
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    region: westus
+    cidr: 10.1.0.0/16
+    state: query
+  register: nm_query_subnet_all_azure
+
+- name: Verify nm_query_subnet_all_aws and nm_query_subnet_all_azure
+  assert:
+    that:
+    - nm_query_subnet_all_aws is not changed
+    - nm_query_subnet_all_aws.current[0].ip == '10.0.0.0/24'
+    - nm_query_subnet_all_aws.current[0].zone == 'us-west-1a'
+    - nm_query_subnet_all_azure is not changed
+    - nm_query_subnet_all_azure.current[0].ip == '10.1.0.0/24'
+    - nm_query_subnet_all_azure.current[0].zone == ''
+    - nm_query_subnet_all_azure.current[1].ip == '10.1.1.0/24'
+    - nm_query_subnet_all_azure.current[1].zone == ''
+
+# REMOVE SUBNETS
+- name: Remove Subnet from CIDR (check_mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_present
+    state: absent
+  check_mode: yes
+  register: cm_remove_subnet
+
+- name: Verify cm_remove_subnet
+  assert:
+    that:
+    - cm_remove_subnet is changed
+    - cm_remove_subnet.current == {}
+
+- name: Remove Subnet from CIDR (normal mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_present
+    state: absent
+  register: nm_remove_subnet
+
+- name: Verify nm_remove_subnet
+  assert:
+    that:
+    - nm_remove_subnet is changed
+    - nm_remove_subnet.current == {}
+
+- name: Remove Subnet from CIDR again (check_mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_present
+    state: absent
+  check_mode: yes
+  register: cm_remove_subnet_again
+
+- name: Verify cm_remove_subnet_again
+  assert:
+    that:
+    - cm_remove_subnet_again is not changed
+    - cm_remove_subnet_again.current == {}
+
+- name: Remove Subnet from CIDR again (normal mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_present
+    state: absent
+  register: nm_remove_subnet_again
+
+- name: Verify nm_remove_subnet_again
+  assert:
+    that:
+    - nm_remove_subnet_again is not changed
+    - nm_remove_subnet_again.current == {}
+
+# QUERY NON-EXISTING subnet in CIDR
+- name: Query non-existing subnet (check_mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    subnet: non_existing_subnet
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_query_non_subnet
+
+- name: Query non-existing subnet (normal mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    subnet: non_existing_subnet
+  ignore_errors: yes
+  register: nm_query_non_subnet
+
+- name: Verify query_non_subnet
+  assert:
+    that:
+    - cm_query_non_subnet is not changed
+    - nm_query_non_subnet is not changed
+    - cm_query_non_subnet == nm_query_non_subnet
+    - cm_query_non_subnet.msg is match("Subnet IP 'non_existing_subnet' not found")
+    - nm_query_non_subnet.msg is match("Subnet IP 'non_existing_subnet' not found")
+
+# QUERY NON-EXISTING CIDR
+- name: Query non-existing CIDR (check_mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    cidr: non_existing_cidr
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_query_non_cidr
+
+- name: Query non-existing CIDR (normal mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    cidr: non_existing_cidr
+  ignore_errors: yes
+  register: nm_query_non_cidr
+
+- name: Verify query_non_cidr
+  assert:
+    that:
+    - cm_query_non_cidr is not changed
+    - nm_query_non_cidr is not changed
+    - cm_query_non_cidr == nm_query_non_cidr
+    - cm_query_non_cidr.msg == nm_query_non_cidr.msg == "Provided CIDR IP 'non_existing_cidr' does not exist. Existing CIDR IPs{{':'}} 10.0.0.0/16. Use mso_schema_site_vrf_region_cidr to create it."
+
+# QUERY NON-EXISTING region
+- name: Query non-existing region (check_mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    region: non_existing_region
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_query_non_region
+
+- name: Query non-existing region (normal mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    region: non_existing_region
+  ignore_errors: yes
+  register: nm_query_non_region
+
+- name: Verify query_non_region
+  assert:
+    that:
+    - cm_query_non_region is not changed
+    - nm_query_non_region is not changed
+    - cm_query_non_region == nm_query_non_region
+    - cm_query_non_region.msg == nm_query_non_region.msg == "Provided region 'non_existing_region' does not exist. Existing regions{{':'}} us-west-1. Use mso_schema_site_vrf_region_cidr to create it."
+
+# QUERY NON-EXISTING VRF
+- name: Query non-existing VRF (check_mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    vrf: non_existing_vrf
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_query_non_vrf
+
+- name: Query non-existing VRF (normal mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    vrf: non_existing_vrf
+  ignore_errors: yes
+  register: nm_query_non_vrf
+
+- name: Verify query_non_vrf
+  assert:
+    that:
+    - cm_query_non_vrf is not changed
+    - nm_query_non_vrf is not changed
+    - cm_query_non_vrf == nm_query_non_vrf
+    - cm_query_non_vrf.msg == nm_query_non_vrf.msg == "Provided vrf 'non_existing_vrf' does not exist at site level. Use mso_schema_site_vrf_region_cidr to create it."
+
+# USE A NON-EXISTING STATE
+- name: Non-existing state for site cidr subnet (check_mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    state: non-existing-state
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_non_existing_state
+
+- name: Non-existing state for site cidr subnet (normal_mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    state: non-existing-state
+  ignore_errors: yes
+  register: nm_non_existing_state
+
+- name: Verify non_existing_state
+  assert:
+    that:
+    - cm_non_existing_state is not changed
+    - nm_non_existing_state is not changed
+    - cm_non_existing_state == nm_non_existing_state
+    - cm_non_existing_state.msg == nm_non_existing_state.msg == "value of state must be one of{{':'}} absent, present, query, got{{':'}} non-existing-state"
+
+# USE A NON-EXISTING SCHEMA
+- name: Non-existing schema for site cidr subnet (check_mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    schema: non-existing-schema
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_non_existing_schema
+
+- name: Non-existing schema for site cidr subnet (normal_mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    schema: non-existing-schema
+  ignore_errors: yes
+  register: nm_non_existing_schema
+
+- name: Verify non_existing_schema
+  assert:
+    that:
+    - cm_non_existing_schema is not changed
+    - nm_non_existing_schema is not changed
+    - cm_non_existing_schema == nm_non_existing_schema
+    - cm_non_existing_schema.msg == nm_non_existing_schema.msg == "Provided schema 'non-existing-schema' does not exist"
+
+# USE A NON-EXISTING TEMPLATE
+- name: Non-existing template for site cidr subnet (check_mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    template: non-existing-template
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_non_existing_template
+
+- name: Non-existing template for site cidr subnet (normal_mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    template: non-existing-template
+  ignore_errors: yes
+  register: nm_non_existing_template
+
+- name: Verify non_existing_template
+  assert:
+    that:
+    - cm_non_existing_template is not changed
+    - nm_non_existing_template is not changed
+    - cm_non_existing_template == nm_non_existing_template
+    - cm_non_existing_template.msg == nm_non_existing_template.msg == "Provided template 'non-existing-template' does not exist. Existing templates{{':'}} Template 1, Template 2"
+
+# USE A NON-ASSOCIATED TEMPLATE
+- name: Non-associated template for site cidr subnet (check_mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    template: Template 2
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_non_associated_template
+
+- name: Non-associated template for site cidr subnet (normal_mode)
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_query
+    template: Template 2
+  ignore_errors: yes
+  register: nm_non_associated_template
+
+- name: Verify non_associated_template
+  assert:
+    that:
+    - cm_non_associated_template is not changed
+    - nm_non_associated_template is not changed
+    - cm_non_associated_template == nm_non_associated_template
+    - cm_non_associated_template.msg is match("Provided site/siteId/template 'aws_ansible_test/[0-9a-zA-Z]*/Template 2' does not exist. Existing siteIds/templates{{':'}} [0-9a-zA-Z]*/Template 1")
+    - nm_non_associated_template.msg is match("Provided site/siteId/template 'aws_ansible_test/[0-9a-zA-Z]*/Template 2' does not exist. Existing siteIds/templates{{':'}} [0-9a-zA-Z]*/Template 1")

--- a/tests/integration/targets/mso_schema_site_vrf_region_cidr_subnet/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf_region_cidr_subnet/tasks/main.yml
@@ -47,6 +47,15 @@
     - https://{{ azure_apic_hostname }}
     state: present
 
+- name: Remove Schemas
+  mso_schema:
+    <<: *mso_info
+    schema: item
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
 - name: Ensure tenant ansible_test exist
   mso_tenant: 
     <<: *mso_info
@@ -73,12 +82,6 @@
     cloud_account: uni/tn-ansible_test/act-[9]-vendor-azure
     state: present
 
-- name: Remove Schemas
-  mso_schema:
-    <<: *mso_info
-    schema: '{{ mso_schema | default("ansible_test") }}'
-    state: absent
-      
 - name: Ensure schema 1 with Template 1 exists
   mso_schema_template: 
     <<: *mso_info

--- a/tests/integration/targets/mso_schema_site_vrf_region_cidr_subnet/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf_region_cidr_subnet/tasks/main.yml
@@ -13,7 +13,7 @@
 
 # CLEAN ENVIRONMENT
 - name: Set vars
-  set_fact: 
+  set_fact:
     mso_info: &mso_info
       host: '{{ mso_hostname }}'
       username: '{{ mso_username }}'
@@ -57,7 +57,7 @@
   - '{{ mso_schema | default("ansible_test") }}'
 
 - name: Ensure tenant ansible_test exist
-  mso_tenant: 
+  mso_tenant:
     <<: *mso_info
     tenant: ansible_test
     users:
@@ -65,7 +65,7 @@
     state: present
 
 - name: Ensure AWS site is present under tenant ansible_test
-  mso_tenant_site: 
+  mso_tenant_site:
     <<: *mso_info
     tenant: ansible_test
     site: 'aws_{{ mso_site | default("ansible_test") }}'
@@ -75,7 +75,7 @@
     state: present
 
 - name: Ensure Azure site is present under tenant ansible_test
-  mso_tenant_site: 
+  mso_tenant_site:
     <<: *mso_info
     tenant: ansible_test
     site: 'azure_{{ mso_site | default("ansible_test") }}'
@@ -83,7 +83,7 @@
     state: present
 
 - name: Ensure schema 1 with Template 1 exists
-  mso_schema_template: 
+  mso_schema_template:
     <<: *mso_info
     schema: '{{ mso_schema | default("ansible_test") }}'
     tenant: ansible_test
@@ -108,7 +108,7 @@
   loop: '{{ sites }}'
 
 - name: Ensure VRF1 exists
-  mso_schema_template_vrf: 
+  mso_schema_template_vrf:
     <<: *mso_info
     schema: '{{ mso_schema | default("ansible_test") }}'
     template: Template 1
@@ -116,7 +116,7 @@
     state: present
 
 - name: Ensure VRF1 exists
-  mso_schema_template_vrf: 
+  mso_schema_template_vrf:
     <<: *mso_info
     schema: '{{ mso_schema | default("ansible_test") }}'
     template: Template 1

--- a/tests/integration/targets/mso_schema_site_vrf_region_cidr_subnet/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf_region_cidr_subnet/tasks/main.yml
@@ -22,8 +22,8 @@
       use_ssl: '{{ mso_use_ssl | default(true) }}'
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("info") }}'
-    sites: "[ { 'site': 'aws_{{ mso_site | default(\'ansible_test\') }}', 'region': 'us-west-1', 'cidr': '10.0.0.0/16'}, 
-              { 'site': 'azure_{{ mso_site | default(\'ansible_test\') }}', 'region': 'westus', 'cidr': '10.1.0.0/16'}]"
+    sites: "[ { 'site': 'aws_{{ mso_site | default(\"ansible_test\") }}', 'region': 'us-west-1', 'cidr': '10.0.0.0/16'}, 
+              { 'site': 'azure_{{ mso_site | default(\"ansible_test\") }}', 'region': 'westus', 'cidr': '10.1.0.0/16'}]"
 
 - name: Ensure site exists
   mso_site:

--- a/tests/integration/targets/mso_schema_template_anp_epg/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_anp_epg/tasks/main.yml
@@ -29,6 +29,21 @@
 #     - https://{{ apic_hostname }}
 #     state: present
 
+- name: Remove schemas
+  mso_schema:
+    host: '{{ mso_hostname }}'
+    username: '{{ mso_username }}'
+    password: '{{ mso_password }}'
+    validate_certs: '{{ mso_validate_certs | default(false) }}'
+    use_ssl: '{{ mso_use_ssl | default(true) }}'
+    use_proxy: '{{ mso_use_proxy | default(true) }}'
+    output_level: '{{ mso_output_level | default("info") }}'
+    schema: '{{ item }}'
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
 - name: Ensure tenant ansible_test exist
   mso_tenant: &tenant_present
     host: '{{ mso_hostname }}'
@@ -44,21 +59,6 @@
     # sites:
     # - '{{ mso_site | default("ansible_test") }}'
     state: present
-
-- name: Remove schemas
-  mso_schema:
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
-    schema: '{{ item }}'
-    state: absent
-  loop:
-  - '{{ mso_schema | default("ansible_test") }}_2'
-  - '{{ mso_schema | default("ansible_test") }}'
 
 - name: Ensure schema 1 with Template 1 exist
   mso_schema_template: &schema_present

--- a/tests/integration/targets/mso_schema_template_anp_epg/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_anp_epg/tasks/main.yml
@@ -1123,3 +1123,40 @@
   assert:
     that:
     - nm_query_contract_epg.current.contractRelationships | length == 4
+
+# Checking if issue when querying EPG and VRF is not defined (#66)
+- name: Add new test EPG 3 (normal mode)
+  mso_schema_template_anp_epg: &epg_present_2
+    host: '{{ mso_hostname }}'
+    username: '{{ mso_username }}'
+    password: '{{ mso_password }}'
+    validate_certs: '{{ mso_validate_certs | default(false) }}'
+    use_ssl: '{{ mso_use_ssl | default(true) }}'
+    use_proxy: '{{ mso_use_proxy | default(true) }}'
+    output_level: '{{ mso_output_level | default("info") }}'
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_3
+    bd:
+      name: ansible_test_1
+  register: nm_add_epg_3
+
+- name: Verify nm_add_epg_3
+  assert:
+    that:
+    - nm_add_epg_3 is changed
+    - nm_add_epg_3.current.name == 'ansible_test_3'
+    - "'vrfRef' not in nm_add_epg_3.current"
+
+- name: Query test EPG 3
+  mso_schema_template_anp_epg:
+    <<: *epg_present_2
+  register: nm_query_epg_3
+
+- name: Verify nm_query_epg_3
+  assert:
+    that:
+    - nm_query_epg_3 is not changed
+    - nm_query_epg_3.current.name == 'ansible_test_3'
+    - "'vrfRef' not in nm_query_epg_3.current"

--- a/tests/integration/targets/mso_schema_template_anp_epg_contract/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_anp_epg_contract/tasks/main.yml
@@ -29,6 +29,21 @@
 #     - https://{{ apic_hostname }}
 #     state: present
 
+- name: Remove schemas
+  mso_schema:
+    host: '{{ mso_hostname }}'
+    username: '{{ mso_username }}'
+    password: '{{ mso_password }}'
+    validate_certs: '{{ mso_validate_certs | default(false) }}'
+    use_ssl: '{{ mso_use_ssl | default(true) }}'
+    use_proxy: '{{ mso_use_proxy | default(true) }}'
+    output_level: '{{ mso_output_level | default("info") }}'
+    schema: '{{ item }}'
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
 - name: Ensure tenant ansible_test exist
   mso_tenant: &tenant_present
     host: '{{ mso_hostname }}'
@@ -44,21 +59,6 @@
     # sites:
     # - '{{ mso_site | default("ansible_test") }}'
     state: present
-
-- name: Remove schemas
-  mso_schema:
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
-    schema: '{{ item }}'
-    state: absent
-  loop:
-  - '{{ mso_schema | default("ansible_test") }}_2'
-  - '{{ mso_schema | default("ansible_test") }}'
 
 - name: Ensure schema 1 with Template 1 exist
   mso_schema_template: &schema_present

--- a/tests/integration/targets/mso_schema_template_anp_epg_selector/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_anp_epg_selector/tasks/main.yml
@@ -41,6 +41,15 @@
 #     - https://{{ apic_hostname }}
 #     state: present
 
+- name: Remove schemas
+  mso_schema:
+    <<: *mso_info
+    schema: '{{ item }}'
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
 - name: Ensure tenant ansible_test exist
   mso_tenant: 
     <<: *mso_info
@@ -50,15 +59,6 @@
     # sites:
     # - '{{ mso_site | default("ansible_test") }}'
     state: present
-
-- name: Remove schemas
-  mso_schema:
-    <<: *mso_info
-    schema: '{{ item }}'
-    state: absent
-  loop:
-  - '{{ mso_schema | default("ansible_test") }}_2'
-  - '{{ mso_schema | default("ansible_test") }}'
 
 - name: Ensure schema 1 with Template 1 exist
   mso_schema_template: 

--- a/tests/integration/targets/mso_schema_template_bd/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_bd/tasks/main.yml
@@ -29,6 +29,21 @@
     - https://{{ apic_hostname }}
     state: present
 
+- name: Remove schemas
+  mso_schema:
+    host: '{{ mso_hostname }}'
+    username: '{{ mso_username }}'
+    password: '{{ mso_password }}'
+    validate_certs: '{{ mso_validate_certs | default(false) }}'
+    use_ssl: '{{ mso_use_ssl | default(true) }}'
+    use_proxy: '{{ mso_use_proxy | default(true) }}'
+    output_level: '{{ mso_output_level | default("info") }}'
+    schema: '{{ item }}'
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
 - name: Ensure tenant ansible_test exist
   mso_tenant: &tenant_present
     host: '{{ mso_hostname }}'
@@ -44,21 +59,6 @@
     sites:
     - '{{ mso_site | default("ansible_test") }}'
     state: present
-
-- name: Remove schemas
-  mso_schema:
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
-    schema: '{{ item }}'
-    state: absent
-  loop:
-  - '{{ mso_schema | default("ansible_test") }}_2'
-  - '{{ mso_schema | default("ansible_test") }}'
 
 - name: Ensure schema 1 with Template 1 exist
   mso_schema_template: &schema_present

--- a/tests/integration/targets/mso_schema_template_contract_filter/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_contract_filter/tasks/main.yml
@@ -29,7 +29,22 @@
 #     urls:
 #     - https://{{ apic_hostname }}
 #     state: present
-    
+
+- name: Remove schemas
+  mso_schema:
+    host: '{{ mso_hostname }}'
+    username: '{{ mso_username }}'
+    password: '{{ mso_password }}'
+    validate_certs: '{{ mso_validate_certs | default(false) }}'
+    use_ssl: '{{ mso_use_ssl | default(true) }}'
+    use_proxy: '{{ mso_use_proxy | default(true) }}'
+    output_level: '{{ mso_output_level | default("info") }}'
+    schema: '{{ item }}'
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
 - name: Ensure tenant ansible_test exist
   mso_tenant: &tenant_present
     host: '{{ mso_hostname }}'
@@ -45,25 +60,6 @@
     # sites:
     # - '{{ mso_site | default("ansible_test") }}'
     state: present
-
-- name: Remove schema 2
-  mso_schema:
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    schema: '{{ mso_schema | default("ansible_test") }}_2'
-    validate_certs: false
-    state: absent
-
-- name: Remove schema 1
-  mso_schema:
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    schema: '{{ mso_schema | default("ansible_test") }}'
-    validate_certs: false
-    state: absent
-
 
 - name: Ensure schema 1 with Template 1 exist
   mso_schema_template: &schema_present

--- a/tests/integration/targets/mso_schema_template_external_epg_contract/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_external_epg_contract/tasks/main.yml
@@ -29,6 +29,21 @@
 #     - https://{{ apic_hostname }}
 #     state: present
 
+- name: Remove schemas
+  mso_schema:
+    host: '{{ mso_hostname }}'
+    username: '{{ mso_username }}'
+    password: '{{ mso_password }}'
+    validate_certs: '{{ mso_validate_certs | default(false) }}'
+    use_ssl: '{{ mso_use_ssl | default(true) }}'
+    use_proxy: '{{ mso_use_proxy | default(true) }}'
+    output_level: '{{ mso_output_level | default("info") }}'
+    schema: '{{ item }}'
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
 - name: Ensure tenant ansible_test exist
   mso_tenant: &tenant_present
     host: '{{ mso_hostname }}'
@@ -44,21 +59,6 @@
     # sites:
     # - '{{ mso_site | default("ansible_test") }}'
     state: present
-
-- name: Remove schemas
-  mso_schema:
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
-    schema: '{{ item }}'
-    state: absent
-  loop:
-  - '{{ mso_schema | default("ansible_test") }}_2'
-  - '{{ mso_schema | default("ansible_test") }}'
 
 - name: Ensure schema 1 with Template 1 exist
   mso_schema_template: &schema_present

--- a/tests/integration/targets/mso_schema_template_external_epg_selector/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_external_epg_selector/tasks/main.yml
@@ -23,6 +23,15 @@
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("info") }}'
 
+- name: Remove schemas
+  mso_schema:
+    <<: *mso_info
+    schema: '{{ item }}'
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
 - name: Ensure tenant ansible_test exist
   mso_tenant: 
     <<: *mso_info
@@ -32,15 +41,6 @@
     # sites:
     # - '{{ mso_site | default("ansible_test") }}'
     state: present
-
-- name: Remove schemas
-  mso_schema:
-    <<: *mso_info
-    schema: '{{ item }}'
-    state: absent
-  loop:
-  - '{{ mso_schema | default("ansible_test") }}_2'
-  - '{{ mso_schema | default("ansible_test") }}'
 
 - name: Ensure schema 1 with Template 1 exist
   mso_schema_template: 

--- a/tests/integration/targets/mso_schema_template_externalepg/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_externalepg/tasks/main.yml
@@ -41,6 +41,15 @@
 #     - https://{{ apic_hostname }}
 #     state: present
 
+- name: Remove schemas
+  mso_schema:
+    <<: *mso_info
+    schema: '{{ item }}'
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
 - name: Ensure tenant ansible_test exist
   mso_tenant: 
     <<: *mso_info
@@ -50,15 +59,6 @@
     # sites:
     # - '{{ mso_site | default("ansible_test") }}'
     state: present
-
-- name: Remove schemas
-  mso_schema:
-    <<: *mso_info
-    schema: '{{ item }}'
-    state: absent
-  loop:
-  - '{{ mso_schema | default("ansible_test") }}_2'
-  - '{{ mso_schema | default("ansible_test") }}'
 
 - name: Ensure schema 1 with Template 1 exist
   mso_schema_template: 

--- a/tests/integration/targets/mso_schema_template_vrf_contract/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_vrf_contract/tasks/main.yml
@@ -41,6 +41,15 @@
 #     - https://{{ apic_hostname }}
 #     state: present
 
+- name: Remove schemas
+  mso_schema:
+    <<: *mso_info
+    schema: '{{ item }}'
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
 - name: Ensure tenant ansible_test exist
   mso_tenant: 
     <<: *mso_info
@@ -50,15 +59,6 @@
     # sites:
     # - '{{ mso_site | default("ansible_test") }}'
     state: present
-
-- name: Remove schemas
-  mso_schema:
-    <<: *mso_info
-    schema: '{{ item }}'
-    state: absent
-  loop:
-  - '{{ mso_schema | default("ansible_test") }}_2'
-  - '{{ mso_schema | default("ansible_test") }}'
 
 - name: Ensure schema 1 with Template 1 exist
   mso_schema_template: 


### PR DESCRIPTION
Fix mso_schema_site_vrf_region_cidr to automatically create VRF and Region if not present at site level
Add support for VGW attribute in mso_schema_site_vrf_region_cidr_subnet
Remove unused regions attribute from mso_schema_template_vrf
Add test for mso_schema_site_vrf_region_cidr module
Add test for mso_schema_site_vrf_region_cidr_subnet module

Resolves #50 
Resolves #66 