### PR TITLE
azure/aws endpoint selector module for EPG (Site level)

### DIFF
--- a/plugins/modules/mso_schema_site_anp_epg_selector.py
+++ b/plugins/modules/mso_schema_site_anp_epg_selector.py
@@ -55,7 +55,7 @@ options:
       type:
         description:
         - The type of the expression.
-        - The type is customized or in [ region, zone, ip_address ]
+        - The type is custom or is one of region, zone and ip_address
         - The type can be zone only when the site is AWS.
         required: true
         type: str
@@ -63,13 +63,14 @@ options:
       operator:
         description:
         - The operator associated to the expression.
+        - Operator has_key or does_not_have_key is only available for custom type / tag
         required: true
         type: str
         choices: [ not_in, in, equals, not_equals, has_key, does_not_have_key ]
       value:
         description:
         - The value associated to the expression.
-        - If the operator is in or not_in, the value should be a comma separated str.
+        - If the operator is in or not_in, the value should be a comma separated string.
         type: str
   state:
     description:
@@ -332,27 +333,27 @@ def main():
         all_expressions = []
         if expressions:
             for expression in expressions:
-                tag = expression.get('type')
+                type = expression.get('type')
                 operator = expression.get('operator')
                 value = expression.get('value')
-                if " " in tag:
-                    mso.fail_json(msg="There should not be any space in 'type' attribute of expression '{0}'".format(tag))
+                if " " in type:
+                    mso.fail_json(msg="There should not be any space in 'type' attribute of expression '{0}'".format(type))
                 if operator in ["has_key", "does_not_have_key"] and value:
                     mso.fail_json(
-                        msg="Attribute 'value' is not supported for operator '{0}' in expression '{1}'".format(operator, tag))
+                        msg="Attribute 'value' is not supported for operator '{0}' in expression '{1}'".format(operator, type))
                 if operator in ["not_in", "in", "equals", "not_equals"] and not value:
                     mso.fail_json(
-                        msg="Attribute 'value' needed for operator '{0}' in expression '{1}'".format(operator, tag))
-                if tag in ["region", "zone", "ip_address"]:
-                    if tag == "zone" and site_type != "aws":
+                        msg="Attribute 'value' needed for operator '{0}' in expression '{1}'".format(operator, type))
+                if type in ["region", "zone", "ip_address"]:
+                    if type == "zone" and site_type != "aws":
                         mso.fail_json(msg="Type 'zone' is only supported for aws")
                     if operator in ["has_key", "does_not_have_key"]:
-                        mso.fail_json(msg="Operator '{0}' is not supported when expression type is '{1}'".format(operator, tag))
-                    tag = EXPRESSION_KEYS.get(tag)
+                        mso.fail_json(msg="Operator '{0}' is not supported when expression type is '{1}'".format(operator, type))
+                    type = EXPRESSION_KEYS.get(type)
                 else:
-                    tag = 'Custom:' + tag
+                    type = 'Custom:' + type
                 all_expressions.append(dict(
-                    key=tag,
+                    key=type,
                     operator=EXPRESSION_OPERATORS.get(operator),
                     value=value,
                 ))

--- a/plugins/modules/mso_schema_site_anp_epg_selector.py
+++ b/plugins/modules/mso_schema_site_anp_epg_selector.py
@@ -192,7 +192,7 @@ def main():
     state = module.params.get('state')
 
     mso = MSOModule(module)
-    mso.stdout = "start \n"
+
     # Get schema_id
     schema_obj = mso.get_obj('schemas', displayName=schema)
     if not schema_obj:
@@ -208,7 +208,7 @@ def main():
 
     # Get site
     site_id = mso.lookup_site(site)
-    #mso.stdout += "site id is " + str(site_id) + "\n"
+
     # Get site_idx
     sites = [(s.get('siteId'), s.get('templateName')) for s in schema_obj.get('sites')]
     if (site_id, template) not in sites:
@@ -226,7 +226,6 @@ def main():
     # Get ANP
     anp_ref = mso.anp_ref(schema_id=schema_id, template=template, anp=anp)
     anps = [a.get('anpRef') for a in schema_obj['sites'][site_idx]['anps']]
-    mso.stdout += "anps under site " + str(anps) + "\n"
     anps_path = '/sites/{0}/anps'.format(site_template)
     anps_in_temp = [a.get('name') for a in schema_obj['templates'][template_idx]['anps']]
     if anp not in anps_in_temp:
@@ -311,7 +310,6 @@ def main():
         elif not mso.existing:
             mso.fail_json(msg="Selector '{selector}' not found".format(selector=selector))
         mso.exit_json()
-
 
     mso.previous = mso.existing
     if state == 'absent':

--- a/tests/integration/targets/mso_schema_site_anp_epg_domain/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_domain/tasks/main.yml
@@ -34,13 +34,8 @@
 - name: Ensure site exists
   mso_site:
     <<: *mso_info
-    site: '{{ mso_site | default("ansible_test") }}'
-    apic_username: '{{ apic_username }}'
-    apic_password: '{{ apic_password }}'
-    apic_site_id: '{{ apic_site_id | default(101) }}'
-    urls:
-    - https://{{ apic_hostname }}
-    state: present
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    state: absent
 
 - name: Ensure tenant ansible_test exist
   mso_tenant: 

--- a/tests/integration/targets/mso_schema_site_anp_epg_domain/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_domain/tasks/main.yml
@@ -22,6 +22,15 @@
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("info") }}'
 
+- name: Remove Schemas
+  mso_schema:
+    <<: *mso_info
+    schema: item
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
 - name: Ensure site exists
   mso_site:
     <<: *mso_info
@@ -32,15 +41,6 @@
     urls:
     - https://{{ apic_hostname }}
     state: present
-
-- name: Remove Schemas
-  mso_schema:
-    <<: *mso_info
-    schema: item
-    state: absent
-  loop:
-  - '{{ mso_schema | default("ansible_test") }}_2'
-  - '{{ mso_schema | default("ansible_test") }}'
 
 - name: Ensure tenant ansible_test exist
   mso_tenant: 

--- a/tests/integration/targets/mso_schema_site_anp_epg_domain/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_domain/tasks/main.yml
@@ -22,6 +22,17 @@
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("info") }}'
 
+- name: Ensure site exists
+  mso_site:
+    <<: *mso_info
+    site: '{{ mso_site | default("ansible_test") }}'
+    apic_username: '{{ apic_username }}'
+    apic_password: '{{ apic_password }}'
+    apic_site_id: '{{ apic_site_id | default(101) }}'
+    urls:
+    - https://{{ apic_hostname }}
+    state: present
+
 - name: Remove Schemas
   mso_schema:
     <<: *mso_info
@@ -30,12 +41,6 @@
   loop:
   - '{{ mso_schema | default("ansible_test") }}_2'
   - '{{ mso_schema | default("ansible_test") }}'
-
-- name: Ensure site exists
-  mso_site:
-    <<: *mso_info
-    schema: '{{ mso_schema | default("ansible_test") }}'
-    state: absent
 
 - name: Ensure tenant ansible_test exist
   mso_tenant: 

--- a/tests/integration/targets/mso_schema_site_anp_epg_selector/aliases
+++ b/tests/integration/targets/mso_schema_site_anp_epg_selector/aliases
@@ -1,0 +1,2 @@
+# No ACI MultiSite infrastructure, so not enabled
+# unsupported

--- a/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
@@ -640,6 +640,24 @@
     - nm_remove_site_selector_3 is changed
     - nm_remove_site_selector_3.current == {}
 
+- name: Remove site selector 3 again (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_3
+    state: absent
+  register: nm_remove_site_selector_3_again
+
+- name: Verify nm_remove_site_selector_3_again
+  assert:
+    that:
+    - nm_remove_site_selector_3_again is not changed
+    - nm_remove_site_selector_3_again.current == {}
+
 # QUERY NON-EXISTING Selector to EPG
 - name: Query non-existing selector (check_mode)
   mso_schema_site_anp_epg_selector:

--- a/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
@@ -154,42 +154,6 @@
   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1' }
   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_2' }
 
-# Remove all selector to EPG ansible_test_1 (normal_mode)
-- name: Remove selectors to EPG (normal_mode)
-  mso_schema_template_anp_epg_selector:
-    <<: *mso_info
-    schema: '{{ item.schema }}'
-    template: '{{ item.template }}'
-    anp: ANP
-    epg: '{{ item.epg }}'
-    selector: '{{ item.selector }}'
-    state: absent
-  ignore_errors: yes
-  loop:
-  - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'selector_1' }
-  - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'selector_2' }
-  - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'selector_3' }
-  - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'selector_4' }
-
-# Remove all selector to site EPG ansible_test_1 (normal_mode)
-- name: Remove site selectors to EPG (normal_mode)
-  mso_schema_site_anp_epg_selector:
-    <<: *mso_info
-    schema: '{{ item.schema }}'
-    site: '{{ item.site }}'
-    template: '{{ item.template }}'
-    anp: ANP
-    epg: '{{ item.epg }}'
-    selector: '{{ item.selector }}'
-    state: absent
-  ignore_errors: yes
-  loop:
-  - { schema: '{{ mso_schema | default("ansible_test") }}', site: 'aws_{{ mso_site | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'site_selector_1' }
-  - { schema: '{{ mso_schema | default("ansible_test") }}', site: 'aws_{{ mso_site | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'site_selector_2' }
-  - { schema: '{{ mso_schema | default("ansible_test") }}', site: 'aws_{{ mso_site | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'site_selector_3' }
-  - { schema: '{{ mso_schema | default("ansible_test") }}', site: 'aws_{{ mso_site | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'site_selector_4' }
-  - { schema: '{{ mso_schema | default("ansible_test") }}', site: 'azure_{{ mso_site | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'site_selector_1' }
-
 - name: Add Selector to EPG (normal_mode)
   mso_schema_template_anp_epg_selector:
     <<: *mso_info
@@ -1031,3 +995,23 @@
     that:
     - nm_add_azure_site_selector_1 is not changed
     - nm_add_azure_site_selector_1.msg == "Type 'zone' is only supported for aws"
+
+- name: Remove schemas
+  mso_schema:
+    <<: *mso_info
+    schema: '{{ item }}'
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
+- name: Dissociate clouds that are associated with ansible_tenant
+  mso_tenant_site:
+    <<: *mso_info
+    tenant: ansible_test
+    site: '{{ item }}'
+    state: absent
+  loop:
+  - '{{ mso_site | default("ansible_test") }}'
+  - 'aws_{{ mso_site | default("ansible_test") }}'
+  - 'azure_{{ mso_site | default("ansible_test") }}'

--- a/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
@@ -22,111 +22,113 @@
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("info") }}'
 
-# - name: Remove schemas
-#   mso_schema:
-#     <<: *mso_info
-#     schema: '{{ item }}'
-#     state: absent
-#   loop:
-#   - '{{ mso_schema | default("ansible_test") }}_2'
-#   - '{{ mso_schema | default("ansible_test") }}'
+- name: Remove schemas
+  mso_schema:
+    <<: *mso_info
+    schema: '{{ item }}'
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
 
-# - name: remove anp
-#   mso_schema_template_anp:
-#     <<: *mso_info
-#     schema: '{{ mso_schema | default("ansible_test") }}'
-#     template: '{{ item.template }}'
-#     anp: ANP
-#     state: absent
-#   ignore_errors: yes
-#   loop:
-#   - {template: Template 1}
-#   - {template: Template 2}
-#   - {template: Template 3}
+# # - name: remove anp
+# #   mso_schema_template_anp:
+# #     <<: *mso_info
+# #     schema: '{{ mso_schema | default("ansible_test") }}'
+# #     template: '{{ item.template }}'
+# #     anp: ANP
+# #     state: absent
+# #   ignore_errors: yes
+# #   loop:
+# #   - {template: Template 1}
+# #   - {template: Template 2}
+# #   - {template: Template 3}
 
-# # - name: Remove EPGs
-# - name: Remove EPG (normal mode)
-#   mso_schema_template_anp_epg:
-#     <<: *mso_info
-#     schema: '{{ mso_schema | default("ansible_test") }}'
-#     template: Template 1
-#     anp: ANP
-#     epg: ansible_test_1
-#     state: absent
-#   register: nm_remove_epg
+# # # - name: Remove EPGs
+# # - name: Remove EPG (normal mode)
+# #   mso_schema_template_anp_epg:
+# #     <<: *mso_info
+# #     schema: '{{ mso_schema | default("ansible_test") }}'
+# #     template: Template 1
+# #     anp: ANP
+# #     epg: ansible_test_1
+# #     state: absent
+# #   register: nm_remove_epg
 
-# - name: Remove site EPG (normal mode)
-#   mso_schema_site_anp_epg:
-#     <<: *mso_info
-#     schema: '{{ mso_schema | default("ansible_test") }}'
-#     site: 'aws_{{ mso_site | default("ansible_test") }}'
-#     template: Template 1
-#     anp: ANP
-#     epg: ansible_test_1
-#     state: absent
-#   register: nm_remove_site_epg
+# # - name: Remove site EPG (normal mode)
+# #   mso_schema_site_anp_epg:
+# #     <<: *mso_info
+# #     schema: '{{ mso_schema | default("ansible_test") }}'
+# #     site: 'aws_{{ mso_site | default("ansible_test") }}'
+# #     template: Template 1
+# #     anp: ANP
+# #     epg: ansible_test_1
+# #     state: absent
+# #   register: nm_remove_site_epg
 
-# - name: Dissociate clouds that are associated with ansible_tenant
-#   mso_tenant_site:
-#     <<: *mso_info
-#     tenant: ansible_test
-#     site: '{{ item }}'
-#     state: absent
-#   loop:
-#   - '{{ mso_site | default("ansible_test") }}'
-#   - 'aws_{{ mso_site | default("ansible_test") }}'
-#   - 'azure_{{ mso_site | default("ansible_test") }}'
-#   ignore_errors: true
+# # - name: Dissociate clouds that are associated with ansible_tenant
+# #   mso_tenant_site:
+# #     <<: *mso_info
+# #     tenant: ansible_test
+# #     site: '{{ item }}'
+# #     state: absent
+# #   loop:
+# #   - '{{ mso_site | default("ansible_test") }}'
+# #   - 'aws_{{ mso_site | default("ansible_test") }}'
+# #   - 'azure_{{ mso_site | default("ansible_test") }}'
+# #   ignore_errors: true
 
-# - name: Remove tenant ansible_test
-#   mso_tenant: 
-#     <<: *mso_info
-#     tenant: ansible_test
-#     users:
-#       - '{{ mso_username }}'
-#     state: absent
+# # - name: Remove tenant ansible_test
+# #   mso_tenant: 
+# #     <<: *mso_info
+# #     tenant: ansible_test
+# #     users:
+# #       - '{{ mso_username }}'
+# #     state: absent
 
-# - name: Ensure azure site exists
-#   mso_site:
-#     <<: *mso_info
-#     site: 'azure_{{ mso_site | default("ansible_test") }}'
-#     apic_username: '{{ azure_apic_username }}'
-#     apic_password: '{{ azure_apic_password }}'
-#     apic_site_id: '{{ azure_site_id }}'
-#     urls:
-#     - https://{{ azure_apic_hostname }}
-#     state: present
+- name: Ensure azure site exists
+  mso_site:
+    <<: *mso_info
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    apic_username: '{{ azure_apic_username }}'
+    apic_password: '{{ azure_apic_password }}'
+    apic_site_id: '{{ azure_site_id }}'
+    urls:
+    - https://{{ azure_apic_hostname }}
+    state: present
 
-# - name: Ensure aws site exists
-#   mso_site:
-#     <<: *mso_info
-#     site: 'aws_{{ mso_site | default("ansible_test") }}'
-#     apic_username: '{{ aws_apic_username }}'
-#     apic_password: '{{ aws_apic_password }}'
-#     apic_site_id: '{{ aws_site_id }}'
-#     urls:
-#     - https://{{ aws_apic_hostname }}
-#     state: present
+- name: Ensure aws site exists
+  mso_site:
+    <<: *mso_info
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    apic_username: '{{ aws_apic_username }}'
+    apic_password: '{{ aws_apic_password }}'
+    apic_site_id: '{{ aws_site_id }}'
+    urls:
+    - https://{{ aws_apic_hostname }}
+    state: present
 
-# - name: Ensure tenant ansible_test exists
-#   mso_tenant: 
-#     <<: *mso_info
-#     tenant: ansible_test
-#     users:
-#       - '{{ mso_username }}'
-#     state: present
+- name: Ensure tenant ansible_test exists
+  mso_tenant: 
+    <<: *mso_info
+    tenant: ansible_test
+    users:
+      - '{{ mso_username }}'
+    # sites:
+    # - '{{ mso_site | default("ansible_test") }}'
+    state: present
 
-# - name: Associate aws site with ansible_test in normal mode
-#   mso_tenant_site:
-#     <<: *mso_info
-#     tenant: ansible_test
-#     site: 'aws_{{ mso_site | default("ansible_test") }}'
-#     cloud_account: "000000000000"
-#     aws_trusted: false
-#     aws_access_key: "1"
-#     secret_key: "0"
-#     state: present 
-#   register: aaws_nm
+- name: Associate aws site with ansible_test in normal mode
+  mso_tenant_site:
+    <<: *mso_info
+    tenant: ansible_test
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    cloud_account: "000000000000"
+    aws_trusted: false
+    aws_access_key: "1"
+    secret_key: "0"
+    state: present 
+  register: aaws_nm
 
 # - name: Verify aaws_nm
 #   assert:
@@ -137,21 +139,21 @@
 #     - aaws_nm.current.awsAccount[0].secretKey == '0'
 #     - aaws_nm.current.awsAccount[0].accountId == '000000000000'
 
-# - name: Associate azure site with access_type not present, with ansible_test in normal mode
-#   mso_tenant_site:
-#     <<: *mso_info
-#     tenant: ansible_test
-#     site: 'azure_{{ mso_site | default("ansible_test") }}'
-#     cloud_account: uni/tn-ansible_test/act-[100]-vendor-azure
-#     state: present 
-#   register: aazure_shared_nm
+- name: Associate azure site with access_type not present, with ansible_test in normal mode
+  mso_tenant_site:
+    <<: *mso_info
+    tenant: ansible_test
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    cloud_account: uni/tn-ansible_test/act-[100]-vendor-azure
+    state: present 
+  register: aazure_shared_nm
 
 # - name: Verify aazure_shared_nm
 #   assert:
 #     that:
 #     - aazure_shared_nm is changed
 
-- name: Ensure schema 1 with Template 1 and Template 2 exist
+- name: Ensure schema 1 with Template 1, and Template 2, Template 3 exist
   mso_schema_template:
     <<: *mso_info
     schema: '{{ mso_schema | default("ansible_test") }}'
@@ -163,61 +165,63 @@
   - { template: Template 2}
   - { template: Template 3}
 
-# - name: Ensure schema 2 with Template 3 exist
-#   mso_schema_template:
-#     <<: *mso_info
-#     schema: '{{ mso_schema | default("ansible_test") }}_2'
-#     tenant: ansible_test
-#     template: Template 3
-#     state: present
-
-# # - name: Ensure VRF1 exists
-# #   mso_schema_site_vrf: 
+# # - name: Ensure schema 2 with Template 3 exist
+# #   mso_schema_template:
 # #     <<: *mso_info
-# #     schema: '{{ mso_schema | default("ansible_test") }}'
-# #     site: 'aws_{{ mso_site | default("ansible_test") }}'
-# #     template: Template 1
-# #     vrf: VRF1
+# #     schema: '{{ mso_schema | default("ansible_test") }}_2'
+# #     tenant: ansible_test
+# #     template: Template 3
 # #     state: present
 
-# - name: Add a new site to a schema
-#   mso_schema_site:
-#     <<: *mso_info
-#     schema: '{{ mso_schema | default("ansible_test") }}'
-#     site: 'aws_{{ mso_site | default("ansible_test") }}'
-#     template: Template 1
-#     state: present
 
-# - name: Ensure ANP exist
-#   mso_schema_template_anp:
-#     <<: *mso_info
-#     schema: '{{ item.schema }}'
-#     template: '{{ item.template }}'
-#     anp: ANP
-#     state: present
-#   loop:
-#   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1' }
-#   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 2' }
-#   - { schema: '{{ mso_schema | default("ansible_test") }}_2', template: 'Template 3' }
+- name: Add a new site to a schema
+  mso_schema_site:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: '{{item.template}}'
+    state: present
+  loop:
+  - { template: Template 1}
+  - { template: Template 2}
 
+- name: Ensure VRF1 exists
+  mso_schema_template_vrf: 
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    #site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    vrf: VRF1
+    state: present
 
+- name: Ensure ANP exist
+  mso_schema_template_anp:
+    <<: *mso_info
+    schema: '{{ item.schema }}'
+    template: '{{ item.template }}'
+    anp: ANP
+    state: present
+  loop:
+  - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1' }
+  - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 2' }
+  #- { schema: '{{ mso_schema | default("ansible_test") }}_2', template: 'Template 3' }
 
-# # ADD EPGs
-# - name: Ensure EPGs exist
-#   mso_schema_template_anp_epg:
-#     <<: *mso_info
-#     schema: '{{ item.schema }}'
-#     template: '{{ item.template }}'
-#     anp: ANP
-#     epg: '{{ item.epg }}'
-#     vrf:
-#       name: VRF 1
-#       schema: ansible_test
-#       template: Template 1
-#     state: present
-#   loop:
-#   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1' }
-#   - { schema: '{{ mso_schema | default("ansible_test") }}_2', template: 'Template 3', epg: 'ansible_test_3' }
+# ADD EPGs
+- name: Ensure EPGs exist
+  mso_schema_template_anp_epg:
+    <<: *mso_info
+    schema: '{{ item.schema }}'
+    template: '{{ item.template }}'
+    anp: ANP
+    epg: '{{ item.epg }}'
+    vrf:
+      name: VRF1
+      schema: ansible_test
+      template: Template 1
+    state: present
+  loop:
+  - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1' }
+  - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_2' }
 
 
 # Remove all selector to EPG ansible_test_1 (normal_mode)

--- a/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
@@ -174,11 +174,22 @@
 # #     state: present
 
 
-- name: Add a new site to a schema
+- name: Add aws site to a schema
   mso_schema_site:
     <<: *mso_info
     schema: '{{ mso_schema | default("ansible_test") }}'
     site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: '{{item.template}}'
+    state: present
+  loop:
+  - { template: Template 1}
+  - { template: Template 2}
+
+- name: Add azure site to a schema
+  mso_schema_site:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
     template: '{{item.template}}'
     state: present
   loop:
@@ -239,6 +250,7 @@
   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'selector_1' }
   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'selector_2' }
   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'selector_3' }
+  - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'selector_4' }
 
 # Remove all selector to site EPG ansible_test_1 (normal_mode)
 - name: Remove site selectors to EPG (normal_mode)
@@ -256,7 +268,8 @@
   - { schema: '{{ mso_schema | default("ansible_test") }}', site: 'aws_{{ mso_site | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'site_selector_1' }
   - { schema: '{{ mso_schema | default("ansible_test") }}', site: 'aws_{{ mso_site | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'site_selector_2' }
   - { schema: '{{ mso_schema | default("ansible_test") }}', site: 'aws_{{ mso_site | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'site_selector_3' }
-
+  - { schema: '{{ mso_schema | default("ansible_test") }}', site: 'aws_{{ mso_site | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'site_selector_4' }
+  - { schema: '{{ mso_schema | default("ansible_test") }}', site: 'azure_{{ mso_site | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'site_selector_1' }
 
 - name: Add Selector to EPG (normal_mode)
   mso_schema_template_anp_epg_selector:
@@ -1032,3 +1045,71 @@
     - nm_non_existing_site_template is not changed
     - cm_non_existing_site_template == nm_non_existing_site_template
     - cm_non_existing_site_template.msg == nm_non_existing_site_template.msg == "Provided site-template association 'aws_{{ mso_site | default("ansible_test") }}-Template 3' does not exist."
+
+- name: Add Selector_4 to site EPG (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_4
+    expressions:
+      - type: ip_address
+        operator: has_key
+    state: present
+  ignore_errors: yes
+  register: nm_add_site_selector_4
+
+- name: Verify nm_add_site_selector_4
+  assert:
+    that:
+    - nm_add_site_selector_4 is not changed
+    - nm_add_site_selector_4.msg == "Operator 'has_key' is not supported when expression type is 'ip_address'"
+
+- name: Add Selector_4 to site EPG again (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_4
+    expressions:
+      - type: ip_address
+        operator: in
+        value: test
+    state: present
+  register: nm_add_site_selector_4_again
+
+- name: Verify nm_add_site_selector_4
+  assert:
+    that:
+    - nm_add_site_selector_4_again is changed
+    - nm_add_site_selector_4_again.current.name == "site_selector_4"
+
+- name: Add azure site_selector_1 to site EPG (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    expressions:
+      - type: zone
+        operator: in
+        value: test
+    state: present
+  ignore_errors: yes
+  register: nm_add_azure_site_selector_1
+
+- name: Verify nm_add_azure_site_selector_1
+  assert:
+    that:
+    - nm_add_azure_site_selector_1 is not changed
+    - nm_add_azure_site_selector_1.msg == "Type 'zone' is only supported for aws"
+

--- a/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
@@ -1,0 +1,1030 @@
+# Test code for the MSO modules
+# Copyright: (c) 2020, Cindy Zhao (@cizhao) <cizhao@cisco.com>
+# Copyright: (c) 2020, Lionel Hercot (@lhercot) <lhercot@cisco.com>
+# Copyright: (c) 2018, Dag Wieers (@dagwieers) <dag@wieers.com> (based on mso_site test case)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI MultiSite host, username and password
+  fail:
+    msg: 'Please define the following variables: mso_hostname, mso_username and mso_password.'
+  when: mso_hostname is not defined or mso_username is not defined or mso_password is not defined
+
+# CLEAN ENVIRONMENT
+- name: Set vars
+  set_fact: 
+    mso_info: &mso_info
+      host: '{{ mso_hostname }}'
+      username: '{{ mso_username }}'
+      password: '{{ mso_password }}'
+      validate_certs: '{{ mso_validate_certs | default(false) }}'
+      use_ssl: '{{ mso_use_ssl | default(true) }}'
+      use_proxy: '{{ mso_use_proxy | default(true) }}'
+      output_level: '{{ mso_output_level | default("info") }}'
+
+# - name: Remove schemas
+#   mso_schema:
+#     <<: *mso_info
+#     schema: '{{ item }}'
+#     state: absent
+#   loop:
+#   - '{{ mso_schema | default("ansible_test") }}_2'
+#   - '{{ mso_schema | default("ansible_test") }}'
+
+# - name: remove anp
+#   mso_schema_template_anp:
+#     <<: *mso_info
+#     schema: '{{ mso_schema | default("ansible_test") }}'
+#     template: '{{ item.template }}'
+#     anp: ANP
+#     state: absent
+#   ignore_errors: yes
+#   loop:
+#   - {template: Template 1}
+#   - {template: Template 2}
+#   - {template: Template 3}
+
+# # - name: Remove EPGs
+# - name: Remove EPG (normal mode)
+#   mso_schema_template_anp_epg:
+#     <<: *mso_info
+#     schema: '{{ mso_schema | default("ansible_test") }}'
+#     template: Template 1
+#     anp: ANP
+#     epg: ansible_test_1
+#     state: absent
+#   register: nm_remove_epg
+
+# - name: Remove site EPG (normal mode)
+#   mso_schema_site_anp_epg:
+#     <<: *mso_info
+#     schema: '{{ mso_schema | default("ansible_test") }}'
+#     site: 'aws_{{ mso_site | default("ansible_test") }}'
+#     template: Template 1
+#     anp: ANP
+#     epg: ansible_test_1
+#     state: absent
+#   register: nm_remove_site_epg
+
+# - name: Dissociate clouds that are associated with ansible_tenant
+#   mso_tenant_site:
+#     <<: *mso_info
+#     tenant: ansible_test
+#     site: '{{ item }}'
+#     state: absent
+#   loop:
+#   - '{{ mso_site | default("ansible_test") }}'
+#   - 'aws_{{ mso_site | default("ansible_test") }}'
+#   - 'azure_{{ mso_site | default("ansible_test") }}'
+#   ignore_errors: true
+
+# - name: Remove tenant ansible_test
+#   mso_tenant: 
+#     <<: *mso_info
+#     tenant: ansible_test
+#     users:
+#       - '{{ mso_username }}'
+#     state: absent
+
+# - name: Ensure azure site exists
+#   mso_site:
+#     <<: *mso_info
+#     site: 'azure_{{ mso_site | default("ansible_test") }}'
+#     apic_username: '{{ azure_apic_username }}'
+#     apic_password: '{{ azure_apic_password }}'
+#     apic_site_id: '{{ azure_site_id }}'
+#     urls:
+#     - https://{{ azure_apic_hostname }}
+#     state: present
+
+# - name: Ensure aws site exists
+#   mso_site:
+#     <<: *mso_info
+#     site: 'aws_{{ mso_site | default("ansible_test") }}'
+#     apic_username: '{{ aws_apic_username }}'
+#     apic_password: '{{ aws_apic_password }}'
+#     apic_site_id: '{{ aws_site_id }}'
+#     urls:
+#     - https://{{ aws_apic_hostname }}
+#     state: present
+
+# - name: Ensure tenant ansible_test exists
+#   mso_tenant: 
+#     <<: *mso_info
+#     tenant: ansible_test
+#     users:
+#       - '{{ mso_username }}'
+#     state: present
+
+# - name: Associate aws site with ansible_test in normal mode
+#   mso_tenant_site:
+#     <<: *mso_info
+#     tenant: ansible_test
+#     site: 'aws_{{ mso_site | default("ansible_test") }}'
+#     cloud_account: "000000000000"
+#     aws_trusted: false
+#     aws_access_key: "1"
+#     secret_key: "0"
+#     state: present 
+#   register: aaws_nm
+
+# - name: Verify aaws_nm
+#   assert:
+#     that:
+#     - aaws_nm is changed
+#     - aaws_nm.current.awsAccount != 'null'
+#     - aaws_nm.current.awsAccount[0].accessKeyId == '1'
+#     - aaws_nm.current.awsAccount[0].secretKey == '0'
+#     - aaws_nm.current.awsAccount[0].accountId == '000000000000'
+
+# - name: Associate azure site with access_type not present, with ansible_test in normal mode
+#   mso_tenant_site:
+#     <<: *mso_info
+#     tenant: ansible_test
+#     site: 'azure_{{ mso_site | default("ansible_test") }}'
+#     cloud_account: uni/tn-ansible_test/act-[100]-vendor-azure
+#     state: present 
+#   register: aazure_shared_nm
+
+# - name: Verify aazure_shared_nm
+#   assert:
+#     that:
+#     - aazure_shared_nm is changed
+
+- name: Ensure schema 1 with Template 1 and Template 2 exist
+  mso_schema_template:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    tenant: ansible_test
+    template: '{{item.template}}'
+    state: present
+  loop:
+  - { template: Template 1}
+  - { template: Template 2}
+  - { template: Template 3}
+
+# - name: Ensure schema 2 with Template 3 exist
+#   mso_schema_template:
+#     <<: *mso_info
+#     schema: '{{ mso_schema | default("ansible_test") }}_2'
+#     tenant: ansible_test
+#     template: Template 3
+#     state: present
+
+# # - name: Ensure VRF1 exists
+# #   mso_schema_site_vrf: 
+# #     <<: *mso_info
+# #     schema: '{{ mso_schema | default("ansible_test") }}'
+# #     site: 'aws_{{ mso_site | default("ansible_test") }}'
+# #     template: Template 1
+# #     vrf: VRF1
+# #     state: present
+
+# - name: Add a new site to a schema
+#   mso_schema_site:
+#     <<: *mso_info
+#     schema: '{{ mso_schema | default("ansible_test") }}'
+#     site: 'aws_{{ mso_site | default("ansible_test") }}'
+#     template: Template 1
+#     state: present
+
+# - name: Ensure ANP exist
+#   mso_schema_template_anp:
+#     <<: *mso_info
+#     schema: '{{ item.schema }}'
+#     template: '{{ item.template }}'
+#     anp: ANP
+#     state: present
+#   loop:
+#   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1' }
+#   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 2' }
+#   - { schema: '{{ mso_schema | default("ansible_test") }}_2', template: 'Template 3' }
+
+
+
+# # ADD EPGs
+# - name: Ensure EPGs exist
+#   mso_schema_template_anp_epg:
+#     <<: *mso_info
+#     schema: '{{ item.schema }}'
+#     template: '{{ item.template }}'
+#     anp: ANP
+#     epg: '{{ item.epg }}'
+#     vrf:
+#       name: VRF 1
+#       schema: ansible_test
+#       template: Template 1
+#     state: present
+#   loop:
+#   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1' }
+#   - { schema: '{{ mso_schema | default("ansible_test") }}_2', template: 'Template 3', epg: 'ansible_test_3' }
+
+
+# Remove all selector to EPG ansible_test_1 (normal_mode)
+- name: Remove selectors to EPG (normal_mode)
+  mso_schema_template_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ item.schema }}'
+    template: '{{ item.template }}'
+    anp: ANP
+    epg: '{{ item.epg }}'
+    selector: '{{ item.selector }}'
+    state: absent
+  ignore_errors: yes
+  loop:
+  - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'selector_1' }
+  - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'selector_2' }
+  - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'selector_3' }
+
+# Remove all selector to site EPG ansible_test_1 (normal_mode)
+- name: Remove site selectors to EPG (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ item.schema }}'
+    site: '{{ item.site }}'
+    template: '{{ item.template }}'
+    anp: ANP
+    epg: '{{ item.epg }}'
+    selector: '{{ item.selector }}'
+    state: absent
+  ignore_errors: yes
+  loop:
+  - { schema: '{{ mso_schema | default("ansible_test") }}', site: 'aws_{{ mso_site | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'site_selector_1' }
+  - { schema: '{{ mso_schema | default("ansible_test") }}', site: 'aws_{{ mso_site | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'site_selector_2' }
+  - { schema: '{{ mso_schema | default("ansible_test") }}', site: 'aws_{{ mso_site | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1', selector: 'site_selector_3' }
+
+
+- name: Add Selector to EPG (normal_mode)
+  mso_schema_template_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: selector_1
+    state: present
+  register: nm_add_selector_1
+
+- name: Verify nm_add_selector_1
+  assert:
+    that:
+    - nm_add_selector_1 is changed
+    - nm_add_selector_1.previous == {}
+    - nm_add_selector_1.current.name == "selector_1"
+    - nm_add_selector_1.current.expressions == []
+
+- name: Add Selector 2 to EPG (normal_mode)
+  mso_schema_template_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: selector_2
+    expressions:
+      - type: expression_1
+        operator: in
+        value: test
+    state: present
+  register: nm_add_selector_2
+
+- name: Verify nm_add_selector_2
+  assert:
+    that:
+    - nm_add_selector_2 is changed
+    - nm_add_selector_2.previous == {}
+    - nm_add_selector_2.current.name == "selector_2"
+    - nm_add_selector_2.current.expressions[0].key == "Custom:expression_1"
+    - nm_add_selector_2.current.expressions[0].operator == "in"
+    - nm_add_selector_2.current.expressions[0].value == "test"
+
+# ADD SELECTORS to site EPG
+- name: Add selector site_selector_1 to site EPG ansible_test_1 with ANP (check_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: present
+  check_mode: yes
+  register: cm_add_site_selector_1
+
+- name: Verify cm_add_site_selector_1
+  assert:
+    that:
+    - cm_add_site_selector_1 is changed
+    - cm_add_site_selector_1.previous == {}
+    - cm_add_site_selector_1.current.name == "site_selector_1"
+    - cm_add_site_selector_1.current.expressions == []
+
+- name: Add selector site_selector_1 to site EPG ansible_test_1 with ANP (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: present
+  register: nm_add_site_selector_1
+
+- name: Verify nm_add_site_selector_1
+  assert:
+    that:
+    - nm_add_site_selector_1 is changed
+    - nm_add_site_selector_1.previous == {}
+    - nm_add_site_selector_1.current.name == "site_selector_1"
+    - nm_add_site_selector_1.current.expressions == []
+
+# Add selector 1 again
+- name: Add selector site_selector_1 to site EPG ansible_test_1 with ANP again (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: present
+  register: nm_add_site_selector_1_again
+
+- name: Verify nm_add_site_selector_1_again
+  assert:
+    that:
+    - nm_add_site_selector_1_again is not changed
+    - nm_add_site_selector_1_again.current.name == "site_selector_1" == nm_add_site_selector_1_again.previous.name
+    - nm_add_site_selector_1_again.current.expressions == [] == nm_add_site_selector_1_again.previous.expressions
+
+- name: Add Selector 1 to site EPG with space in selector name (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: selector 1
+    state: present
+  ignore_errors: yes
+  register: nm_add_selector1_with_space_in_name
+
+- name: Verify nm_add_selector1_with_space_in_name
+  assert:
+    that:
+    - nm_add_selector1_with_space_in_name is not changed
+    - nm_add_selector1_with_space_in_name.msg == "There should not be any space in selector name."
+
+- name: Add Selector 2 to site EPG with space in expression type (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: selector_2
+    expressions:
+      - type: expression 1
+        operator: in
+        value: test
+    state: present
+  ignore_errors: yes
+  register: nm_add_selector2_with_space_in_expression_type
+
+- name: Verify nm_add_selector2_with_space_in_expression_type
+  assert:
+    that:
+    - nm_add_selector2_with_space_in_expression_type is not changed
+    - nm_add_selector2_with_space_in_expression_type.msg == "There should not be any space in 'type' attribute of expression 'expression 1'"
+
+- name: Add Selector 2 to site EPG (check_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_2
+    expressions:
+      - type: expression_1
+        operator: in
+        value: test
+    state: present
+  check_mode: yes
+  register: cm_add_site_selector_2
+
+- name: Verify cm_add_selector_2
+  assert:
+    that:
+    - cm_add_site_selector_2 is changed
+    - cm_add_site_selector_2.previous == {}
+    - cm_add_site_selector_2.current.name == "site_selector_2"
+    - cm_add_site_selector_2.current.expressions[0].key == "Custom:expression_1"
+    - cm_add_site_selector_2.current.expressions[0].operator == "in"
+    - cm_add_site_selector_2.current.expressions[0].value == "test"
+
+- name: Add Selector_2 to site EPG (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_2
+    expressions:
+      - type: expression_1
+        operator: in
+        value: test
+    state: present
+  register: nm_add_site_selector_2
+
+- name: Verify nm_add_site_selector_2
+  assert:
+    that:
+    - nm_add_site_selector_2 is changed
+    - nm_add_site_selector_2.previous == {}
+    - nm_add_site_selector_2.current.name == "site_selector_2"
+    - nm_add_site_selector_2.current.expressions[0].key == "Custom:expression_1"
+    - nm_add_site_selector_2.current.expressions[0].operator == "in"
+    - nm_add_site_selector_2.current.expressions[0].value == "test"
+
+- name: Change Selector 2 - keyExist(normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_2
+    expressions:
+      - type: expression_5
+        operator: has_key
+        value: test
+    state: present
+  ignore_errors: yes
+  register: nm_change_site_selector_2_key_exist
+
+- name: Verify nm_change_site_selector_2_key_exist
+  assert:
+    that:
+    - nm_change_site_selector_2_key_exist is not changed
+    - nm_change_site_selector_2_key_exist.msg == "Attribute 'value' is not supported for operator 'has_key' in expression 'expression_5'"
+
+- name: Change Selector 2 - keyNotExist (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_2
+    expressions:
+      - type: expression_6
+        operator: does_not_have_key
+        value: test
+    state: present
+  ignore_errors: yes
+  register: nm_change_site_selector_2_key_not_exist
+
+- name: Verify nm_change_site_selector_2_key_not_exist
+  assert:
+    that:
+    - nm_change_site_selector_2_key_not_exist is not changed
+    - nm_change_site_selector_2_key_not_exist.msg == "Attribute 'value' is not supported for operator 'does_not_have_key' in expression 'expression_6'"
+
+- name: Change Selector 2 - equals (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_2
+    expressions:
+      - type: expression_6
+        operator: equals
+    state: present
+  ignore_errors: yes
+  register: nm_change_site_selector_2_equals
+
+- name: Verify nm_change_site_selector_2_equals
+  assert:
+    that:
+    - nm_change_site_selector_2_equals is not changed
+    - nm_change_site_selector_2_equals.msg == "Attribute 'value' needed for operator 'equals' in expression 'expression_6'"
+
+# Remove site ANP
+- name: Remove site ANP (normal_mode)
+  mso_schema_site_anp:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    state: absent
+
+- name: Query site ANP
+  mso_schema_site_anp:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    state: query
+  ignore_errors: yes
+  register: query_site_ANP
+
+- name: Verify query_site_ANP
+  assert:
+    that:
+    - query_site_ANP.msg == "ANP 'ANP' not found"
+
+# Query without site ANP
+- name: Query site_selectors without site ANP
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    state: query
+  ignore_errors: yes
+  register: query_without_site_ANP
+
+- name: Verify query_without_site_ANP
+  assert:
+    that:
+    - query_without_site_ANP is not changed
+    - query_without_site_ANP.msg == "Anp 'ANP' does not exist in site level."
+
+# - name: Add selector without ANP exist in site level
+- name: Add site selector 3 without site ANP exist (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_3
+    expressions:
+        - type: expression_1
+          operator: in
+          value: test
+    state: present
+  register: nm_add_site_selector_3_without_anp
+
+- name: Verify nm_add_site_selector_3_without_anp
+  assert:
+    that:
+    - nm_add_site_selector_3_without_anp is changed
+    - nm_add_site_selector_3_without_anp.previous == {}
+    - nm_add_site_selector_3_without_anp.current.name == "site_selector_3"
+    - nm_add_site_selector_3_without_anp.current.expressions[0].key == "Custom:expression_1"
+    - nm_add_site_selector_3_without_anp.current.expressions[0].operator == "in"
+    - nm_add_site_selector_3_without_anp.current.expressions[0].value == "test"
+
+# Remove site level EPG
+- name: Remove site EPG
+  mso_schema_site_anp_epg:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    state: absent
+
+# Query without site level EPG
+- name: Query site_selectors without site EPG
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    state: query
+  ignore_errors: yes
+  register: query_without_site_EPG
+
+- name: Verify query_without_site_EPG
+  assert:
+    that:
+    - query_without_site_EPG is not changed
+    - query_without_site_EPG.msg == "Epg 'ansible_test_1' does not exist in site level."
+
+- name: Add site selector 1 without site EPG exist (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: present
+  register: nm_add_site_selector_1_without_epg
+
+- name: Verify nm_add_site_selector_1_without_epg
+  assert:
+    that:
+    - nm_add_site_selector_1_without_epg is changed
+    - nm_add_site_selector_1_without_epg.previous == {}
+    - nm_add_site_selector_1_without_epg.current.name == "site_selector_1"
+    - nm_add_site_selector_1_without_epg.current.expressions == []
+
+- name: Add site_selector_1 site_selector_2 site_selector_3 again
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: '{{ item.selector }}'
+    expressions:
+      - type: expression_1
+        operator: in
+        value: test
+    state: present
+  loop:
+  - {selector: 'site_selector_1'}
+  - {selector: 'site_selector_2'}
+  - {selector: 'site_selector_3'}
+  register: nm_add_site_selectors_again
+
+- name: Verify nm_add_site_selectors_again
+  assert:
+    that:
+    - nm_add_site_selectors_again is changed
+
+# Query all selectors
+- name: Query selectors to site EPG
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    state: query
+  register: query_all_site_selectors
+
+- name: Verify query_all_site_selectors
+  assert:
+    that:
+    - query_all_site_selectors is not changed
+    - query_all_site_selectors.current | length == 3
+    - query_all_site_selectors.current[0].name == "site_selector_1"
+    - query_all_site_selectors.current[0].expressions[0].key == "Custom:expression_1"
+    - query_all_site_selectors.current[0].expressions[0].operator == "in"
+    - query_all_site_selectors.current[0].expressions[0].value == "test"
+    - query_all_site_selectors.current[1].name == "site_selector_2"
+    - query_all_site_selectors.current[1].expressions[0].key == "Custom:expression_1"
+    - query_all_site_selectors.current[1].expressions[0].operator == "in"
+    - query_all_site_selectors.current[1].expressions[0].value == "test"
+    - query_all_site_selectors.current[2].name == "site_selector_3"
+    - query_all_site_selectors.current[2].expressions[0].key == "Custom:expression_1"
+    - query_all_site_selectors.current[2].expressions[0].operator == "in"
+    - query_all_site_selectors.current[2].expressions[0].value == "test"
+
+# Query sepecific seletor to site EPG
+- name: Query selector to site EPG
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: query
+  register: query_site_selector_1
+
+- name: Verify query_site_selector_1
+  assert:
+    that:
+    - query_site_selector_1 is not changed
+    - query_site_selector_1.current.name == "site_selector_1"
+    - query_site_selector_1.current.expressions[0].key == "Custom:expression_1"
+    - query_site_selector_1.current.expressions[0].operator == "in"
+    - query_site_selector_1.current.expressions[0].value == "test"
+
+- name: Remove site selector 3 (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_3
+    state: absent
+  register: nm_remove_site_selector_3
+
+- name: Verify nm_remove_site_selector_3
+  assert:
+    that:
+    - nm_remove_site_selector_3 is changed
+    - nm_remove_site_selector_3.current == {}
+
+# QUERY NON-EXISTING Selector to EPG
+- name: Query non-existing selector (check_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: non_existing_selector
+    state: query
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_query_non_selector
+
+- name: Query non-existing selector (normal mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: non_existing_selector
+    state: query
+  ignore_errors: yes
+  register: nm_query_non_selector
+
+- name: Verify cm_query_non_selector and nm_query_non_selector
+  assert:
+    that:
+    - cm_query_non_selector is not changed
+    - nm_query_non_selector is not changed
+    - cm_query_non_selector == nm_query_non_selector
+    - cm_query_non_selector.msg == "Selector 'non_existing_selector' not found"
+    - nm_query_non_selector.msg == "Selector 'non_existing_selector' not found"
+
+# QUERY NON-EXISTING EPG
+- name: Query non-existing EPG (check_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: non_existing_epg
+    selector: site_selector_1
+    state: query
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_query_non_epg
+
+- name: Query non-existing EPG (normal mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: non_existing_epg
+    selector: site_selector_1
+    state: query
+  ignore_errors: yes
+  register: nm_query_non_epg
+
+- name: Verify query_non_epg
+  assert:
+    that:
+    - cm_query_non_epg is not changed
+    - nm_query_non_epg is not changed
+    - cm_query_non_epg == nm_query_non_epg
+    - cm_query_non_epg.msg == nm_query_non_epg.msg == "Provided EPG 'non_existing_epg' does not exist. Existing EPGs{{':'}} ansible_test_1, ansible_test_2"
+
+# QUERY NON-EXISTING ANP
+- name: Query non-existing ANP (check_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: non_existing_anp
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: query
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_query_non_anp
+
+- name: Query non-existing ANP (normal mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: non_existing_anp
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: query
+  ignore_errors: yes
+  register: nm_query_non_anp
+
+- name: Verify query_non_anp
+  assert:
+    that:
+    - cm_query_non_anp is not changed
+    - nm_query_non_anp is not changed
+    - cm_query_non_anp == nm_query_non_anp
+    - cm_query_non_anp.msg == nm_query_non_anp.msg == "Provided anp 'non_existing_anp' does not exist. Existing anps{{':'}} ANP"
+
+# USE A NON-EXISTING STATE
+- name: Non-existing state (check_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: non-existing-state
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_non_existing_state
+
+- name: Non-existing state (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: non-existing-state
+  ignore_errors: yes
+  register: nm_non_existing_state
+
+- name: Verify non_existing_state
+  assert:
+    that:
+    - cm_non_existing_state is not changed
+    - nm_non_existing_state is not changed
+    - cm_non_existing_state == nm_non_existing_state
+    - cm_non_existing_state.msg == nm_non_existing_state.msg == "value of state must be one of{{':'}} absent, present, query, got{{':'}} non-existing-state"
+
+# USE A NON-EXISTING TEMPLATE
+- name: Non-existing template (check_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: non-existing-template
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: query
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_non_existing_template
+
+- name: Non-existing template (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: non-existing-template
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: query
+  ignore_errors: yes
+  register: nm_non_existing_template
+
+- name: Verify non_existing_template
+  assert:
+    that:
+    - cm_non_existing_template is not changed
+    - nm_non_existing_template is not changed
+    - cm_non_existing_template == nm_non_existing_template
+    - cm_non_existing_template.msg == nm_non_existing_template.msg == "Provided template 'non-existing-template' does not exist. Existing templates{{':'}} Template 1, Template 2, Template 3"
+
+# USE A NON-EXISTING SCHEMA
+- name: Non-existing schema (check_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: non-existing-schema
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: query
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_non_existing_schema
+
+- name: Non-existing schema (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: non-existing-schema
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: query
+  ignore_errors: yes
+  register: nm_non_existing_schema
+
+- name: Verify non_existing_schema
+  assert:
+    that:
+    - cm_non_existing_schema is not changed
+    - nm_non_existing_schema is not changed
+    - cm_non_existing_schema == nm_non_existing_schema
+    - cm_non_existing_schema.msg == nm_non_existing_schema.msg == "Provided schema 'non-existing-schema' does not exist"
+
+# USE A NON-EXISTING SITE
+- name: Non-existing site (check_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: non-existing-site
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: query
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_non_existing_site
+
+- name: Non-existing site (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: non-existing-site
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: query
+  ignore_errors: yes
+  register: nm_non_existing_site
+
+- name: Verify non_existing_site
+  assert:
+    that:
+    - cm_non_existing_site is not changed
+    - nm_non_existing_site is not changed
+    - cm_non_existing_site == nm_non_existing_site
+    - cm_non_existing_site.msg == nm_non_existing_site.msg == "Site 'non-existing-site' is not a valid site name."
+
+# USE A NON-EXISTING SITE-TEMPLATE 
+- name: Non-existing site-template (check_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 3
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: query
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_non_existing_site_template
+
+- name: Non-existing site-template  (normal_mode)
+  mso_schema_site_anp_epg_selector:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    template: Template 3
+    anp: ANP
+    epg: ansible_test_1
+    selector: site_selector_1
+    state: query
+  ignore_errors: yes
+  register: nm_non_existing_site_template
+
+- name: Verify non_existing_site_template
+  assert:
+    that:
+    - cm_non_existing_site_template is not changed
+    - nm_non_existing_site_template is not changed
+    - cm_non_existing_site_template == nm_non_existing_site_template
+    - cm_non_existing_site_template.msg == nm_non_existing_site_template.msg == "Provided site-template association 'aws_{{ mso_site | default("ansible_test") }}-Template 3' does not exist."

--- a/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
@@ -1112,4 +1112,3 @@
     that:
     - nm_add_azure_site_selector_1 is not changed
     - nm_add_azure_site_selector_1.msg == "Type 'zone' is only supported for aws"
-

--- a/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
@@ -31,61 +31,6 @@
   - '{{ mso_schema | default("ansible_test") }}_2'
   - '{{ mso_schema | default("ansible_test") }}'
 
-# # - name: remove anp
-# #   mso_schema_template_anp:
-# #     <<: *mso_info
-# #     schema: '{{ mso_schema | default("ansible_test") }}'
-# #     template: '{{ item.template }}'
-# #     anp: ANP
-# #     state: absent
-# #   ignore_errors: yes
-# #   loop:
-# #   - {template: Template 1}
-# #   - {template: Template 2}
-# #   - {template: Template 3}
-
-# # # - name: Remove EPGs
-# # - name: Remove EPG (normal mode)
-# #   mso_schema_template_anp_epg:
-# #     <<: *mso_info
-# #     schema: '{{ mso_schema | default("ansible_test") }}'
-# #     template: Template 1
-# #     anp: ANP
-# #     epg: ansible_test_1
-# #     state: absent
-# #   register: nm_remove_epg
-
-# # - name: Remove site EPG (normal mode)
-# #   mso_schema_site_anp_epg:
-# #     <<: *mso_info
-# #     schema: '{{ mso_schema | default("ansible_test") }}'
-# #     site: 'aws_{{ mso_site | default("ansible_test") }}'
-# #     template: Template 1
-# #     anp: ANP
-# #     epg: ansible_test_1
-# #     state: absent
-# #   register: nm_remove_site_epg
-
-# # - name: Dissociate clouds that are associated with ansible_tenant
-# #   mso_tenant_site:
-# #     <<: *mso_info
-# #     tenant: ansible_test
-# #     site: '{{ item }}'
-# #     state: absent
-# #   loop:
-# #   - '{{ mso_site | default("ansible_test") }}'
-# #   - 'aws_{{ mso_site | default("ansible_test") }}'
-# #   - 'azure_{{ mso_site | default("ansible_test") }}'
-# #   ignore_errors: true
-
-# # - name: Remove tenant ansible_test
-# #   mso_tenant: 
-# #     <<: *mso_info
-# #     tenant: ansible_test
-# #     users:
-# #       - '{{ mso_username }}'
-# #     state: absent
-
 - name: Ensure azure site exists
   mso_site:
     <<: *mso_info
@@ -130,15 +75,6 @@
     state: present 
   register: aaws_nm
 
-# - name: Verify aaws_nm
-#   assert:
-#     that:
-#     - aaws_nm is changed
-#     - aaws_nm.current.awsAccount != 'null'
-#     - aaws_nm.current.awsAccount[0].accessKeyId == '1'
-#     - aaws_nm.current.awsAccount[0].secretKey == '0'
-#     - aaws_nm.current.awsAccount[0].accountId == '000000000000'
-
 - name: Associate azure site with access_type not present, with ansible_test in normal mode
   mso_tenant_site:
     <<: *mso_info
@@ -147,11 +83,6 @@
     cloud_account: uni/tn-ansible_test/act-[100]-vendor-azure
     state: present 
   register: aazure_shared_nm
-
-# - name: Verify aazure_shared_nm
-#   assert:
-#     that:
-#     - aazure_shared_nm is changed
 
 - name: Ensure schema 1 with Template 1, and Template 2, Template 3 exist
   mso_schema_template:
@@ -164,15 +95,6 @@
   - { template: Template 1}
   - { template: Template 2}
   - { template: Template 3}
-
-# # - name: Ensure schema 2 with Template 3 exist
-# #   mso_schema_template:
-# #     <<: *mso_info
-# #     schema: '{{ mso_schema | default("ansible_test") }}_2'
-# #     tenant: ansible_test
-# #     template: Template 3
-# #     state: present
-
 
 - name: Add aws site to a schema
   mso_schema_site:
@@ -200,7 +122,6 @@
   mso_schema_template_vrf: 
     <<: *mso_info
     schema: '{{ mso_schema | default("ansible_test") }}'
-    #site: 'aws_{{ mso_site | default("ansible_test") }}'
     template: Template 1
     vrf: VRF1
     state: present
@@ -215,7 +136,6 @@
   loop:
   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1' }
   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 2' }
-  #- { schema: '{{ mso_schema | default("ansible_test") }}_2', template: 'Template 3' }
 
 # ADD EPGs
 - name: Ensure EPGs exist
@@ -233,7 +153,6 @@
   loop:
   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_1' }
   - { schema: '{{ mso_schema | default("ansible_test") }}', template: 'Template 1', epg: 'ansible_test_2' }
-
 
 # Remove all selector to EPG ansible_test_1 (normal_mode)
 - name: Remove selectors to EPG (normal_mode)


### PR DESCRIPTION
build module 'mso_schema_site_anp_epg_selector' to manage azure/aws endpoint selector for site-level EPG
build test file for module 'mso_schema_site_anp_epg_selector' 

* the test file works in MSO 2.2.4 while fails in MSO 3.0(x) due to API validation changes

resolve #63 