### PR TITLE
Fix API error when pushing back EPG with existing contract and add tests

### DIFF
--- a/plugins/modules/mso_schema_template_anp_epg.py
+++ b/plugins/modules/mso_schema_template_anp_epg.py
@@ -373,6 +373,9 @@ def main():
         mso.sanitize(payload, collate=True)
 
         if mso.existing:
+            # Clean contractRef to fix api issue
+            for contract in mso.sent.get('contractRelationships'):
+                contract['contractRef'] = mso.dict_from_ref(contract.get('contractRef'))
             ops.append(dict(op='replace', path=epg_path, value=mso.sent))
         else:
             ops.append(dict(op='add', path=epgs_path + '/-', value=mso.sent))

--- a/tests/integration/targets/mso_schema_template_anp_epg/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_anp_epg/tasks/main.yml
@@ -1160,3 +1160,33 @@
     - nm_query_epg_3 is not changed
     - nm_query_epg_3.current.name == 'ansible_test_3'
     - "'vrfRef' not in nm_query_epg_3.current"
+
+# Checking if modifying an EPG with existing contracts throw an MSO error. (#82)
+- name: Change EPG 2 to add VRF (normal_mode)
+  mso_schema_template_anp_epg:
+    <<: *epg_present
+    epg: ansible_test_2
+    vrf:
+      name: VRF2
+    bd:
+      name: ansible_test_2
+  register: nm_change_epg_2_vrf
+
+- name: Verify that EPG 2 did change
+  assert:
+    that:
+    - nm_change_epg_2_vrf is changed
+    - nm_change_epg_2_vrf.current.vrfRef.templateName == "Template 1"
+    - nm_change_epg_2_vrf.current.vrfRef.vrfName == "VRF2"
+    - nm_change_epg_2_vrf.current.bdRef.bdName == "ansible_test_2"
+
+- name: Query EPG 2
+  mso_schema_template_anp_epg:
+    <<: *epg_query
+    epg: ansible_test_2
+  register: nm_query_contract_epg_2
+
+- name: Verify that 4 contracts are in EPG 2 using nm_query_contract_epg_2
+  assert:
+    that:
+    - nm_query_contract_epg_2.current.contractRelationships | length == 4

--- a/tests/integration/targets/mso_schema_template_external_epg/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_external_epg/tasks/main.yml
@@ -907,3 +907,39 @@
   assert:
     that:
     - nm_query_epg1_contract_again.current.contractRelationships | length == 4
+
+# Checking if modifying an external EPG with existing contracts throw an MSO error. (#82)
+- name: Change external EPG 1 VRF (normal_mode)
+  mso_schema_template_external_epg:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    external_epg: ansible_test_1
+    vrf:
+      name: VRF2
+    l3out:
+      name: L3out2
+    state: present
+  register: nm_change_ext_epg_1_vrf
+
+- name: Verify that external EPG 1 did change
+  assert:
+    that:
+    - nm_change_ext_epg_1_vrf is changed
+    - nm_change_ext_epg_1_vrf.current.vrfRef.templateName == "Template 1"
+    - nm_change_ext_epg_1_vrf.current.vrfRef.vrfName == "VRF2"
+    - nm_change_ext_epg_1_vrf.current.l3outRef.l3outName == "L3out2"
+
+- name: Query EPG 1
+  mso_schema_template_external_epg:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    external_epg: ansible_test_1
+    state: query
+  register: nm_query_contract_ext_epg_1
+
+- name: Verify that 4 contracts are in external EPG 1 using nm_query_contract_ext_epg_1
+  assert:
+    that:
+    - nm_query_contract_ext_epg_1.current.contractRelationships | length == 4

--- a/tests/integration/targets/mso_schema_template_vrf/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_vrf/tasks/main.yml
@@ -415,3 +415,37 @@
     that:
     - nm_query_vrf_contract_again is not changed
     - nm_query_vrf_contract_again.current | length == 2
+
+# Checking if modifying VRF with existing contracts throw an MSO error. (#82)
+- name: Change VRF (normal_mode)
+  mso_schema_template_vrf:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    vrf: VRF
+    vzany: true
+    layer3_multicast: true
+    state: present
+  register: nm_change_vrf
+
+- name: Verify that VRF did change
+  assert:
+    that:
+    - nm_change_vrf is changed
+    - nm_change_vrf.current.name == "VRF"
+    - nm_change_vrf.current.l3MCast == True
+
+- name: Verify contract VRF again
+  mso_schema_template_vrf_contract:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    vrf: VRF
+    state: query
+  register: nm_query_change_vrf_contract_again
+
+- name: Verify 2 contracts are in VRF
+  assert:
+    that:
+    - nm_query_change_vrf_contract_again is not changed
+    - nm_query_change_vrf_contract_again.current | length == 2

--- a/tests/integration/targets/mso_schema_template_vrf/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_vrf/tasks/main.yml
@@ -144,6 +144,8 @@
     schema: '{{ mso_schema | default("ansible_test") }}'
     template: Template 2
     vrf: VRF2
+    layer3_multicast: true
+    vzany: true
     state: present
   register: vrf2_nm
 
@@ -153,6 +155,8 @@
     - vrf2_nm is changed
     - vrf2_nm.current.name == 'VRF2'
     - vrf2_nm.current.displayName == 'VRF2'
+    - vrf2_nm.current.vzAnyEnabled == True
+    - vrf2_nm.current.l3MCast == True
 
 - name: Add VRF3 (normal mode)
   mso_schema_template_vrf:
@@ -177,6 +181,8 @@
     schema: '{{ mso_schema | default("ansible_test") }}'
     template: Template 2
     vrf: VRF2
+    layer3_multicast: true
+    vzany: true
     state: present
   register: vrf2_nm_again
 
@@ -199,6 +205,67 @@
   assert:
     that:
     - vrf4_nm_stateless is changed
+
+# CHANGE VRF SETTINGS
+- name: Change VRF1 settings (check mode)
+  mso_schema_template_vrf:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    vrf: VRF1
+    layer3_multicast: true
+    vzany: true
+    state: present
+  check_mode: yes
+  register: vrf1_change_cm
+
+- name: Change VRF1 settings (normal mode)
+  mso_schema_template_vrf:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    vrf: VRF1
+    layer3_multicast: true
+    vzany: true
+    state: present
+  register: vrf1_change_nm
+
+- name: Change VRF2 settings (check mode)
+  mso_schema_template_vrf:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 2
+    vrf: VRF2
+    layer3_multicast: false
+    vzany: false
+    state: present
+  check_mode: yes
+  register: vrf2_change_cm
+
+- name: Change VRF2 settings (normal mode)
+  mso_schema_template_vrf:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 2
+    vrf: VRF2
+    layer3_multicast: false
+    vzany: false
+    state: present
+  register: vrf2_change_nm
+
+- name: Verify vrf2_nm
+  assert:
+    that:
+    - vrf1_change_cm is changed
+    - vrf1_change_nm is changed
+    - vrf2_change_cm is changed
+    - vrf2_change_nm is changed
+    - vrf1_change_cm.current.name == vrf1_change_nm.current.name == 'VRF1'
+    - vrf2_change_cm.current.name == vrf2_change_nm.current.name == 'VRF2'
+    - vrf1_change_cm.current.vzAnyEnabled == vrf1_change_nm.current.vzAnyEnabled == True
+    - vrf1_change_cm.current.vzAnyEnabled == vrf1_change_nm.current.l3MCast == True
+    - vrf2_change_cm.current.vzAnyEnabled == vrf2_change_nm.current.vzAnyEnabled == False
+    - vrf2_change_cm.current.vzAnyEnabled == vrf2_change_nm.current.l3MCast == False
 
 # QUERY A VRF
 - name: Query VRF2 (normal mode)


### PR DESCRIPTION
Fix API error when pushing EPG with existing contracts.
Add test to mso_schema_template_vrf, mso_schema_template_external_epg and mso_schema_template_anp_epg to check for API error when pushing changes to object with existing contract.
Add missing tests for VRF settings and changing those settings.

Resolves #82 