### PR TITLE
[mso_schema_template_migrate ] solves migration of BDs and EPGs across templates by creating new module - Object migration solves issue #89

### DIFF
--- a/plugins/module_utils/mso.py
+++ b/plugins/module_utils/mso.py
@@ -160,6 +160,13 @@ def mso_hub_network_spec():
     )
 
 
+def mso_object_migrate_spec():
+    return dict(
+        epg=dict(type='str', required=True),
+        anp=dict(type='str', required=True),
+    )
+
+
 class MSOModule(object):
 
     def __init__(self, module):

--- a/plugins/modules/mso_schema_template_migrate.py
+++ b/plugins/modules/mso_schema_template_migrate.py
@@ -1,0 +1,246 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Anvitha Jain (@anvitha-jain) <anvjain@cisco.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: mso_schema_template_migrate
+short_description: Migrate Bridge Domains (BDs) and EPGs between templates
+description:
+- Migrate BDs and EPGs between templates of same and different schemas.
+author:
+- Anvitha Jain (@anvitha-jain)
+options:
+  schema:
+    description:
+    - The name of the schema.
+    type: str
+    required: yes
+  template:
+    description:
+    - The name of the template.
+    type: str
+    required: yes
+  bds:
+    description:
+    - The name of the BDs to migrate.
+    type: list
+    elements: str
+  epgs:
+    description:
+    - The name of the EPGs and the ANP it is in to migrate.
+    type: list
+    elements: dict
+    suboptions:
+      epg:
+        description:
+        - The name of the EPG to migrate.
+        type: str
+        required: yes
+      anp:
+        description:
+        - The name of the anp to migrate.
+        type: str
+        required: yes
+  target_schema:
+    description:
+    - The name of the target_schema.
+    type: str
+    required: yes
+  target_template:
+    description:
+    - The name of the target_template.
+    type: str
+    required: yes
+  state:
+    description:
+    - Use C(present) for adding.
+    type: str
+    default: present
+extends_documentation_fragment: cisco.mso.modules
+'''
+
+EXAMPLES = r'''
+- name: Migration of objects between templates of same schema
+  mso_schema_template_migrate:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    schema: Schema 1
+    template: Template 1
+    target_schema: Schema 1
+    target_template: Template 2
+    bds:
+    - BD
+    epgs:
+    - epg: EPG1
+      anp: ANP
+    state: present
+  delegate_to: localhost
+
+- name: Migration of objects between templates of different schema
+  mso_schema_template_migrate:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    schema: Schema 1
+    template: Template 1
+    target_schema: Schema 2
+    target_template: Template 2
+    bds:
+    - BD
+    epgs:
+    - epg: EPG1
+      anp: ANP
+    state: present
+  delegate_to: localhost
+
+- name: Migration of BD object between templates of same schema
+  mso_schema_template_migrate:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    schema: Schema 1
+    template: Template 1
+    target_schema: Schema 1
+    target_template: Template 2
+    bds:
+    - BD
+    - BD1
+    state: present
+  delegate_to: localhost
+
+- name: Migration of BD object between templates of different schema
+  mso_schema_template_migrate:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    schema: Schema 1
+    template: Template 1
+    target_schema: Schema 2
+    target_template: Template 2
+    bds:
+    - BD
+    - BD1
+    state: present
+  delegate_to: localhost
+
+- name: Migration of EPG objects between templates of same schema
+  mso_schema_template_migrate:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    schema: Schema 1
+    template: Template 1
+    target_schema: Schema 2
+    target_template: Template 2
+    epgs:
+    - epg: EPG1
+      anp: ANP
+    - epg: EPG2
+      anp: ANP2
+    state: present
+  delegate_to: localhost
+
+- name: Migration of EPG objects between templates of different schema
+  mso_schema_template_migrate:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    schema: Schema 1
+    template: Template 1
+    target_schema: Schema 2
+    target_template: Template 2
+    epgs:
+    - epg: EPG1
+      anp: ANP
+    - epg: EPG2
+      anp: ANP2
+    state: present
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec, mso_object_migrate_spec
+
+
+def main():
+    argument_spec = mso_argument_spec()
+    argument_spec.update(
+        schema=dict(type='str', required=True),
+        template=dict(type='str', required=True),
+        bds=dict(type='list', elements='str'),
+        epgs=dict(type='list', elements='dict', options=mso_object_migrate_spec()),
+        target_schema=dict(type='str', required=True),
+        target_template=dict(type='str', required=True),
+        state=dict(type='str', default='present'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    schema = module.params.get('schema')
+    template = module.params.get('template')
+    target_schema = module.params.get('target_schema')
+    target_template = module.params.get('target_template')
+    bds = module.params.get('bds')
+    epgs = module.params.get('epgs')
+    state = module.params.get('state')
+
+    mso = MSOModule(module)
+
+    schema_id = mso.get_obj('schemas', displayName=schema).get('id')
+
+    target_schema_id = mso.get_obj('schemas', displayName=target_schema).get('id')
+
+    if state == 'present':
+        if schema_id is not None:
+            bds_payload = []
+            if bds is not None:
+                for bd in bds:
+                    bds_payload.append(dict(name=bd))
+
+            anp_dict = {}
+            if epgs is not None:
+                for epg in epgs:
+                    if epg.get('anp') in anp_dict:
+                        anp_dict[epg.get('anp')].append(dict(name=epg.get('epg')))
+                    else:
+                        anp_dict[epg.get('anp')] = [dict(name=epg.get('epg'))]
+
+            anps_payload = []
+            for anp, epgs_payload in anp_dict.items():
+                anps_payload.append(dict(name=anp, epgs=epgs_payload))
+
+            payload = dict(
+                targetSchemaId=target_schema_id,
+                targetTemplateName=target_template,
+                bds=bds_payload,
+                anps=anps_payload,
+            )
+
+            template = template.replace(' ', '%20')
+
+            target_template = target_template.replace(' ', '%20')  # removes API error for extra space
+
+            mso.existing = mso.request(path='/api/v1/migrate/schema/{0}/template/{1}'.format(schema_id, template), method='POST', data=payload)
+
+    mso.exit_json()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/mso_schema_template_migrate/aliases
+++ b/tests/integration/targets/mso_schema_template_migrate/aliases
@@ -1,0 +1,2 @@
+# No ACI MultiSite infrastructure, so not enabled
+# unsupported

--- a/tests/integration/targets/mso_schema_template_migrate/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_migrate/tasks/main.yml
@@ -1,0 +1,296 @@
+# Test code for the MSO modules
+# Copyright: (c) 2020, Anvitha Jain (@anvitha-jain) <anvjain@cisco.com>
+# 
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI MultiSite host, username and password
+  fail:
+    msg: 'Please define the following variables: mso_hostname, mso_username and mso_password.'
+  when: mso_hostname is not defined or mso_username is not defined or mso_password is not defined
+
+- name: Set vars
+  set_fact:
+    mso_info: &mso_info
+      host: '{{ mso_hostname }}'
+      username: '{{ mso_username }}'
+      password: '{{ mso_password }}'
+      validate_certs: '{{ mso_validate_certs | default(false) }}'
+      use_ssl: '{{ mso_use_ssl | default(true) }}'
+      use_proxy: '{{ mso_use_proxy | default(true) }}'
+      output_level: '{{ mso_output_level | default("info") }}'
+
+- name: Query MSO version
+  mso_version:
+    <<: *mso_info
+    state: query
+  register: version
+
+# CLEAN ENVIRONMENT
+- name: Ensure site exist
+  mso_site: &site_present
+    host: '{{ mso_hostname }}'
+    username: '{{ mso_username }}'
+    password: '{{ mso_password }}'
+    validate_certs: '{{ mso_validate_certs | default(false) }}'
+    use_ssl: '{{ mso_use_ssl | default(true) }}'
+    use_proxy: '{{ mso_use_proxy | default(true) }}'
+    output_level: '{{ mso_output_level | default("info") }}'
+    site: '{{ mso_site | default("ansible_test") }}'
+    apic_username: '{{ apic_username }}'
+    apic_password: '{{ apic_password }}'
+    apic_site_id: '{{ apic_site_id | default(102) }}'
+    urls:
+    - https://{{ apic_hostname }}
+    state: present
+
+- name: Remove Template 1 and Template 2 of Schema 1
+  mso_schema_template:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    tenant: ansible_test
+    template: '{{ item }}'
+    state: absent
+  ignore_errors: yes
+  loop:
+  - '{{ mso_template1 | default("Template 1") }}'
+  - '{{ mso_template2 | default("Template 2") }}'
+  register: remove_templates_schema1
+
+- name: Remove Template 1 of Schema 2
+  mso_schema_template:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    tenant: ansible_test
+    template: Template 1
+    state: absent
+  ignore_errors: yes
+  register: remove_template1_schema2
+
+- name: Remove schemas
+  mso_schema:
+    host: '{{ mso_hostname }}'
+    username: '{{ mso_username }}'
+    password: '{{ mso_password }}'
+    validate_certs: '{{ mso_validate_certs | default(false) }}'
+    use_ssl: '{{ mso_use_ssl | default(true) }}'
+    use_proxy: '{{ mso_use_proxy | default(true) }}'
+    output_level: '{{ mso_output_level | default("info") }}'
+    schema: '{{ item }}'
+    state: absent
+  loop:
+  - '{{ mso_schema | default("ansible_test") }}_2'
+  - '{{ mso_schema | default("ansible_test") }}'
+
+- name: Ensure tenant ansible_test exist
+  mso_tenant: &tenant_present
+    host: '{{ mso_hostname }}'
+    username: '{{ mso_username }}'
+    password: '{{ mso_password }}'
+    validate_certs: '{{ mso_validate_certs | default(false) }}'
+    use_ssl: '{{ mso_use_ssl | default(true) }}'
+    use_proxy: '{{ mso_use_proxy | default(true) }}'
+    output_level: '{{ mso_output_level | default("info") }}'
+    tenant: ansible_test
+    users:
+    - '{{ mso_username }}'
+    sites:
+    - '{{ mso_site | default("ansible_test") }}'
+    state: present
+
+- name: Ensure schemas with Template 1 exist
+  mso_schema_template: &schema_present
+    host: '{{ mso_hostname }}'
+    username: '{{ mso_username }}'
+    password: '{{ mso_password }}'
+    validate_certs: '{{ mso_validate_certs | default(false) }}'
+    use_ssl: '{{ mso_use_ssl | default(true) }}'
+    use_proxy: '{{ mso_use_proxy | default(true) }}'
+    output_level: '{{ mso_output_level | default("info") }}'
+    schema: '{{ item }}'
+    tenant: ansible_test
+    template: Template 1
+    state: present
+  loop:
+    - '{{ mso_schema | default("ansible_test") }}'
+    - '{{ mso_schema | default("ansible_test") }}_2'
+
+- name: Ensure schema 2 with Template 2 exist
+  mso_schema_template:
+    <<: *schema_present
+    schema: '{{ mso_schema | default("ansible_test") }}_2'
+    tenant: ansible_test
+    template: Template 2
+    state: present
+  register: schema2_template2
+
+- name: Add a new site to a schema 1 with Template 1 in normal mode
+  mso_schema_site:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    state: present
+  register: add_site_nm1
+
+- name: Add a new site to a schema 2 with Template 2 in normal mode
+  mso_schema_site:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}_2'
+    site: '{{ mso_site | default("ansible_test") }}'
+    template: Template 2
+    state: present
+  register: add_site_nm2
+
+- name: Ensure VRF exist
+  mso_schema_template_vrf: &vrf_present
+    host: '{{ mso_hostname }}'
+    username: '{{ mso_username }}'
+    password: '{{ mso_password }}'
+    validate_certs: '{{ mso_validate_certs | default(false) }}'
+    use_ssl: '{{ mso_use_ssl | default(true) }}'
+    use_proxy: '{{ mso_use_proxy | default(true) }}'
+    output_level: '{{ mso_output_level | default("info") }}'
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    vrf: VRF
+    layer3_multicast: true
+    state: present
+
+- name: Ensure ANP exist
+  mso_schema_template_anp:
+    host: '{{ mso_hostname }}'
+    username: '{{ mso_username }}'
+    password: '{{ mso_password }}'
+    validate_certs: '{{ mso_validate_certs | default(false) }}'
+    use_ssl: '{{ mso_use_ssl | default(true) }}'
+    use_proxy: '{{ mso_use_proxy | default(true) }}'
+    output_level: '{{ mso_output_level | default("info") }}'
+    schema: '{{ mso_schema | default("ansible_test") }}_2'
+    template: Template 1
+    anp: ANP
+    state: present
+
+- name: Ensure ANP2 exist
+  mso_schema_template_anp:
+    host: '{{ mso_hostname }}'
+    username: '{{ mso_username }}'
+    password: '{{ mso_password }}'
+    validate_certs: '{{ mso_validate_certs | default(false) }}'
+    use_ssl: '{{ mso_use_ssl | default(true) }}'
+    use_proxy: '{{ mso_use_proxy | default(true) }}'
+    output_level: '{{ mso_output_level | default("info") }}'
+    schema: '{{ mso_schema | default("ansible_test") }}_2'
+    template: Template 1
+    anp: ANP2
+    state: present
+
+- name: Ensure ansible_test_1 BD exist
+  mso_schema_template_bd:
+    <<: *vrf_present
+    schema: '{{ mso_schema | default("ansible_test") }}_2'
+    template: Template 1
+    bd: '{{ item }}'
+    vrf:
+      name: VRF
+      schema: '{{ mso_schema | default("ansible_test") }}'
+      template: Template 1
+    state: present
+  when: version.current.version is version('2.2.4e', '!=')
+  loop:
+    - '{{ BD_1 | default("ansible_test") }}_1'
+    - '{{ BD_2 | default("ansible_test") }}_2'
+
+- name: Ensure EPG exist
+  mso_schema_template_anp_epg: &epg_present
+    host: '{{ mso_hostname }}'
+    username: '{{ mso_username }}'
+    password: '{{ mso_password }}'
+    validate_certs: '{{ mso_validate_certs | default(false) }}'
+    use_ssl: '{{ mso_use_ssl | default(true) }}'
+    use_proxy: '{{ mso_use_proxy | default(true) }}'
+    output_level: '{{ mso_output_level | default("info") }}'
+    schema: '{{ mso_schema | default("ansible_test") }}_2'
+    template: Template 1
+    anp: ANP
+    epg: ansible_test_1
+    bd:
+      name: ansible_test_1
+    vrf:
+      name: VRF
+      schema: '{{ mso_schema | default("ansible_test") }}'
+      template: Template 1
+    state: present
+  register: cm_add_epg
+
+- name: Add EPG 2 (normal mode)
+  mso_schema_template_anp_epg:
+    <<: *epg_present
+    anp: ANP2
+    epg: '{{ item }}'
+  loop:
+    - '{{ EPG_2 | default("ansible_test") }}_2'
+    - '{{ EPG_3 | default("ansible_test") }}_3'
+    - '{{ EPG_4 | default("ansible_test") }}_4'
+
+- name: Migration of objects between templates
+  mso_schema_template_migrate:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}_2'
+    template: Template 1
+    target_schema: '{{ mso_schema | default("ansible_test") }}'
+    target_template: Template 1
+    bds:
+    - ansible_test_1
+    epgs:
+    - epg: ansible_test_1
+      anp: ANP
+    - epg: ansible_test_2
+      anp: ANP2
+    state: present
+  when: version.current.version is version('2.2.4e', '!=')
+  register: object_migrate
+
+- name: Verify object_migrate
+  assert:
+    that:
+    - object_migrate is changed
+
+- name: Migration of BD objects between templates
+  mso_schema_template_migrate:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}_2'
+    template: Template 1
+    target_schema: '{{ mso_schema | default("ansible_test") }}_2'
+    target_template: Template 2
+    bds:
+    - ansible_test_2
+    state: present
+  when: version.current.version is version('2.2.4e', '!=')
+  register: bd_migrate
+
+- name: Verify bd_migrate
+  assert:
+    that:
+    - bd_migrate is changed
+
+- name: Migration of EPG objects between templates
+  mso_schema_template_migrate:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}_2'
+    template: Template 1
+    target_schema: '{{ mso_schema | default("ansible_test") }}_2'
+    target_template: Template 2
+    epgs:
+    - epg: ansible_test_3
+      anp: ANP2
+    - epg: ansible_test_4
+      anp: ANP2
+    state: present
+  when: version.current.version is version('2.2.4e', '!=')
+  register: epg_migrate
+
+- name: Verify schema2_template2
+  assert:
+    that:
+    - schema2_template2 is changed

--- a/tests/integration/targets/mso_schema_template_migrate/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_migrate/tasks/main.yml
@@ -1,6 +1,6 @@
 # Test code for the MSO modules
 # Copyright: (c) 2020, Anvitha Jain (@anvitha-jain) <anvjain@cisco.com>
-# 
+#
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -44,28 +44,43 @@
     - https://{{ apic_hostname }}
     state: present
 
-- name: Remove Template 1 and Template 2 of Schema 1
-  mso_schema_template:
+- name: Undeploy a schema 2 template 2
+  mso_schema_template_deploy:
     <<: *mso_info
-    schema: '{{ mso_schema | default("ansible_test") }}'
-    tenant: ansible_test
-    template: '{{ item }}'
-    state: absent
+    template: Template 2
+    schema: '{{ mso_schema | default("ansible_test") }}_2'
+    site: '{{ mso_site | default("ansible_test") }}'
+    state: undeploy
   ignore_errors: yes
-  loop:
-  - '{{ mso_template1 | default("Template 1") }}'
-  - '{{ mso_template2 | default("Template 2") }}'
-  register: remove_templates_schema1
+  register: undeploy_template2
 
-- name: Remove Template 1 of Schema 2
-  mso_schema_template:
+- name: Undeploy a schema 1 template 1
+  mso_schema_template_deploy:
+    <<: *mso_info
+    template: Template 1
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ mso_site | default("ansible_test") }}'
+    state: undeploy
+  ignore_errors: yes
+  register: undeploy_template1
+
+- name: Remove a site from a schema 1 with Template 1
+  mso_schema_site:
     <<: *mso_info
     schema: '{{ mso_schema | default("ansible_test") }}'
-    tenant: ansible_test
+    site: '{{ mso_site | default("ansible_test") }}'
     template: Template 1
     state: absent
-  ignore_errors: yes
-  register: remove_template1_schema2
+  register: rm_site_temp1
+
+- name: Remove a site from a schema 2 with Template 2
+  mso_schema_site:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}_2'
+    site: '{{ mso_site | default("ansible_test") }}'
+    template: Template 2
+    state: absent
+  register: rm_site_temp2
 
 - name: Remove schemas
   mso_schema:
@@ -251,11 +266,6 @@
   when: version.current.version is version('2.2.4e', '!=')
   register: object_migrate
 
-- name: Verify object_migrate
-  assert:
-    that:
-    - object_migrate is changed
-
 - name: Migration of BD objects between templates
   mso_schema_template_migrate:
     <<: *mso_info
@@ -268,11 +278,6 @@
     state: present
   when: version.current.version is version('2.2.4e', '!=')
   register: bd_migrate
-
-- name: Verify bd_migrate
-  assert:
-    that:
-    - bd_migrate is changed
 
 - name: Migration of EPG objects between templates
   mso_schema_template_migrate:
@@ -290,7 +295,40 @@
   when: version.current.version is version('2.2.4e', '!=')
   register: epg_migrate
 
-- name: Verify schema2_template2
-  assert:
-    that:
-    - schema2_template2 is changed
+- name: Undeploy a schema 2 template 2
+  mso_schema_template_deploy:
+    <<: *mso_info
+    template: Template 2
+    schema: '{{ mso_schema | default("ansible_test") }}_2'
+    site: '{{ mso_site | default("ansible_test") }}'
+    state: undeploy
+  ignore_errors: yes
+  register: undeploy_template2
+
+- name: Undeploy a schema 1 template 1
+  mso_schema_template_deploy:
+    <<: *mso_info
+    template: Template 1
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ mso_site | default("ansible_test") }}'
+    state: undeploy
+  ignore_errors: yes
+  register: undeploy_template1
+
+- name: Remove a site from a schema 1 with Template 1
+  mso_schema_site:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    state: absent
+  register: rm_site_temp1
+
+- name: Remove a site from a schema 2 with Template 2
+  mso_schema_site:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}_2'
+    site: '{{ mso_site | default("ansible_test") }}'
+    template: Template 2
+    state: absent
+  register: rm_site_temp2


### PR DESCRIPTION
The issue #89 is solved by creating a new module to support the migration of Bridge Domains (BDs) and End Point Groups (EPGs) between templates in Schema.