### PR TITLE
Fix issue on mso_schema_site_vrf_region_cidr_subnet to allow an AWS subnet to be used for a TGW Attachment (Hub Network).

### DIFF
--- a/plugins/modules/mso_schema_site_vrf_region_cidr_subnet.py
+++ b/plugins/modules/mso_schema_site_vrf_region_cidr_subnet.py
@@ -65,8 +65,10 @@ options:
     aliases: [ name ]
   vgw:
     description:
-    - Whether this subnet is used for the Azure Gateway.
+    - Whether this subnet is used for the Azure Gateway in Azure.
+    - Whether this subnet is used for the Transit Gateway Attachment in AWS.
     type: bool
+    aliases: [ hub_network ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
@@ -166,7 +168,7 @@ def main():
         cidr=dict(type='str', required=True),
         subnet=dict(type='str', aliases=['ip']),  # This parameter is not required for querying all objects
         zone=dict(type='str', aliases=['name']),
-        vgw=dict(type='bool'),
+        vgw=dict(type='bool', aliases=['hub_network']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
     )
 
@@ -278,7 +280,7 @@ def main():
 
         if zone is not None:
             payload['zone'] = zone
-        elif vgw is True:
+        if vgw is True:
             payload['usage'] = 'gateway'
 
         mso.sanitize(payload, collate=True)

--- a/tests/integration/targets/mso_schema_site_vrf_region_cidr_subnet/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf_region_cidr_subnet/tasks/main.yml
@@ -639,3 +639,38 @@
     - cm_no_site_associated is not changed
     - nm_no_site_associated is not changed
     - cm_no_site_associated.msg == nm_no_site_associated.msg == "No site associated with template 'Template 3'. Associate the site with the template using mso_schema_site."
+
+# Checking if issue when adding subnet to Hub Network (#126)
+- name: Add hub network in VRF1 region us-west-1 at AWS site level
+  mso_schema_site_vrf_region_hub_network:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    vrf: VRF1
+    region: us-west-1
+    hub_network:
+      name: hub-test
+      tenant: infra
+    state: present
+
+- name: Add a new subnet to AWS CIDR in VRF1 at site level
+  mso_schema_site_vrf_region_cidr_subnet:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    vrf: VRF1
+    region: us-west-1
+    cidr: 10.0.0.0/16
+    subnet: 10.0.0.0/24
+    zone: us-west-1a
+    hub_network: true
+    state: present
+  register: nm_add_subnet_hub_network
+
+- name: Verify nm_add_subnet_hub_network
+  assert:
+    that:
+    - nm_add_subnet_hub_network is changed
+    - nm_add_subnet_hub_network.current.usage == 'gateway'


### PR DESCRIPTION
Fix issue on mso_schema_site_vrf_region_cidr_subnet to allow an AWS subnet to be used for a TGW Attachment (Hub Network).
Add hub_network alias to vgw to be clearer for AWS use cases.
Add test case to check that the vgw/hub_network attribute also work on AWS when Hub Network is configured.

Resolves #126 