### PR TITLE
Fix Ansible auth issue with ND/MSO 3.2

### DIFF
--- a/plugins/module_utils/mso.py
+++ b/plugins/module_utils/mso.py
@@ -305,7 +305,7 @@ class MSOModule(object):
                                use_proxy=self.params.get('use_proxy'))
 
         # Handle MSO response
-        if auth.get('status') != 201:
+        if auth.get('status') not in [200, 201]:
             self.response = auth.get('msg')
             self.status = auth.get('status')
             self.fail_json(msg='Authentication failed: {msg}'.format(**auth))


### PR DESCRIPTION
Cisco MSO 3.2 in combination with Nexus Dashboard responds with a 200 OK instead of 201 OK. This fixes the authentication failed error from Ansible with MSO 3.2.