### PR TITLE
Add support for MSO HTTPAPI connection plugin and MSO 3.2 on ND support

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -21,6 +21,8 @@ tags:
 - sdn
 - mso
 - multisite
+dependencies:
+  "ansible.netcommon": "*"
 repository: https://github.com/CiscoDevNet/ansible-mso
 documentation: https://docs.ansible.com/ansible/latest/scenario_guides/guide_aci.html
 homepage: https://cisco.com/go/aci

--- a/plugins/doc_fragments/modules.py
+++ b/plugins/doc_fragments/modules.py
@@ -36,7 +36,7 @@ options:
     type: str
   output_level:
     description:
-    - Influence the output of this ACI module.
+    - Influence the output of this MSO module.
     - C(normal) means the standard output, incl. C(current) dict
     - C(info) adds informational output, incl. C(previous), C(proposed) and C(sent) dicts
     - C(debug) adds debugging output, incl. C(filter_string), C(method), C(response), C(status) and C(url) information
@@ -78,6 +78,6 @@ options:
 requirements:
 - Multi Site Orchestrator v2.1 or newer
 notes:
-- Please read the :ref:`aci_guide` for more detailed information on how to manage your ACI infrastructure using Ansible.
-- This module was written to support ACI Multi Site Orchestrator v2.1 or newer. Some or all functionality may not work on earlier versions.
+- Please read the :ref:`aci_guide` for more detailed information on how to manage your MSO infrastructure using Ansible.
+- This module was written to support Multi Site Orchestrator v2.1 or newer. Some or all functionality may not work on earlier versions.
 '''

--- a/plugins/doc_fragments/modules.py
+++ b/plugins/doc_fragments/modules.py
@@ -16,7 +16,6 @@ options:
     - IP Address or hostname of the ACI Multi Site Orchestrator host.
     - If the value is not specified in the task, the value of environment variable C(MSO_HOST) will be used instead.
     type: str
-    required: yes
     aliases: [ hostname ]
   port:
     description:
@@ -35,7 +34,6 @@ options:
     - The password to use for authentication.
     - If the value is not specified in the task, the value of environment variables C(MSO_PASSWORD) or C(ANSIBLE_NET_PASSWORD) will be used instead.
     type: str
-    required: yes
   output_level:
     description:
     - Influence the output of this ACI module.

--- a/plugins/doc_fragments/modules.py
+++ b/plugins/doc_fragments/modules.py
@@ -78,6 +78,6 @@ options:
 requirements:
 - Multi Site Orchestrator v2.1 or newer
 notes:
-- Please read the :ref:`aci_guide` for more detailed information on how to manage your MSO infrastructure using Ansible.
+- Please read the :ref:`mso_guide` for more detailed information on how to manage your MSO infrastructure using Ansible.
 - This module was written to support Multi Site Orchestrator v2.1 or newer. Some or all functionality may not work on earlier versions.
 '''

--- a/plugins/httpapi/mso.py
+++ b/plugins/httpapi/mso.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2020 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+author: 
+- Lionel Hercot (lhercot)
+httpapi: aci
+short_description: MSO Ansible HTTPAPI Plugin.
+description:
+  - This MSO plugin provides the HTTPAPI transport methods needed to initiate
+    a connection to MSO, send API requests and process the
+    response.
+version_added: "1.2.0"
+"""
+
+import json
+import re
+import pickle
+import ipaddress
+import traceback
+
+from ansible.module_utils.six import PY3
+from ansible.module_utils._text import to_text
+from ansible.module_utils.connection import ConnectionError
+from ansible.plugins.httpapi import HttpApiBase
+
+
+class HttpApi(HttpApiBase):
+
+    def __init__(self, *args, **kwargs):
+        super(HttpApi, self).__init__(*args, **kwargs)
+        self.platform = "cisco.mso"
+        self.headers = {'Content-Type': 'application/json'}
+        self.params = {}
+        self.auth = None
+        self.backup_hosts = None
+        self.host_counter = 0
+
+        self.error = None
+        self.method = 'GET'
+        self.path = ''
+        self.status = -1
+        self.info = {}
+
+    def get_platform(self):
+        return self.platform
+
+    def set_params(self, params):
+        self.params = params
+        # params.get('host')
+        # self.aci_port = params.get('port')
+        # self.aci_user = params.get('username')
+        # self.aci_pass = params.get('password')
+        # self.auth = auth
+        # self.aci_proxy = params.get('use_proxy')
+        # self.aci_ssl = params.get('use_ssl')
+        # self.aci_validate_certs = params.get('validate_certs')
+
+    def set_backup_hosts(self):
+        try:
+            list_of_hosts = re.sub(r'[[\]]', '', self.connection.get_option("host")).split(",")
+            # ipaddress.ip_address(list_of_hosts[0])
+            return list_of_hosts
+        except Exception:
+            return []
+
+    def login(self, username, password):
+        ''' Log in to MSO '''
+        # Perform login request
+        self.connection.queue_message('vvvv', 'Starting Login to {0}'.format(self.connection.get_option('host')))
+
+        method = 'POST'
+        path = '/mso/api/v1/auth/login'
+        full_path = self.connection.get_option('host') + path
+        # TODO: Fix when username and password are not used in MSO module
+        if (self.params.get('login_domain') is not None) and (self.params.get('login_domain') != 'Local'):
+            domain_id = self._get_login_domain_id(self.params.get('login_domain'))
+            payload = {'username': self.params.get('username'), 'password': self.params.get('password'), 'domainId': domain_id}
+        else:
+            payload = {'username': self.params.get('username'), 'password': self.params.get('password')}
+        data = json.dumps(payload)
+        try:
+            self.connection.queue_message('vvvv', 'login() - connection.send({0}, {1}, {2}, {3})'.format(path, data, method, self.headers))
+            response, response_data = self.connection.send(path, data, method=method, headers=self.headers)
+            # raise ConnectionError(self._verify_response(response, method, path, data, response_data))
+            # Handle MSO response
+            self.status = response.getcode()
+            if self.status != 201:
+                self.connection.queue_message('vvvv', 'login status incorrect status={0}'.format(self.status))
+                json_response = self._response_to_json(response_data)
+                self.error = dict(code=self.status, message='Authentication failed: {0}'.format(json_response))
+                raise ConnectionError(json.dumps(self._verify_response(response, method, full_path, response_data)))
+            self.connection._auth = {'Authorization': 'Bearer {0}'.format(self._response_to_json(response_data).get('token'))}
+
+        except ConnectionError:
+            self.connection.queue_message('vvvv', 'login() - ConnectionError Exception')
+            raise
+        except Exception as e:
+            self.connection.queue_message('vvvv', 'login() - Generic Exception')
+            self.error = dict(code=self.status, message='Authentication failed: Request failed: {0}'.format(e))
+            raise ConnectionError(json.dumps(self._verify_response(None, method, full_path, None)))
+
+    def logout(self):
+        method = 'DELETE'
+        path = '/mso/api/v1/auth/logout'
+
+        try:
+            response, response_data = self.connection.send(path, {}, method=method, headers=self.headers)
+        except Exception as e:
+            self.error = dict(code=self.status, message='Error on attempt to logout from MSO. {0}'.format(e))
+            raise ConnectionError(json.dumps(self._verify_response(None, method, self.connection.get_option('host') + path, None)))
+        self.connection._auth = None
+
+    def send_request(self, method, path, data={}):
+        ''' This method handles all MSO REST API requests other than login '''
+
+        self.error = None
+        self.path = ''
+        self.status = -1
+        self.info = {}
+        self.method = 'GET'
+
+        self.connection.queue_message('vvvv', 'send_request method called')
+        # # Case1: List of hosts is provided
+        # self.backup_hosts = self.set_backup_hosts()
+        # if not self.backup_hosts:
+        if self.connection._connected is True and self.params.get('host') != self.connection.get_option('host'):
+            self.connection._connected = False
+            self.connection.queue_message('vvvv', 'send_request reseting connection as host has changed from {0} to {1}'.format(self.connection.get_option('host'), self.params.get('host')))
+
+        if self.params.get('host') is not None:
+            self.connection.set_option('host', self.params.get('host'))
+
+        else:
+            try:
+                with open('my_hosts.pk', 'rb') as fi:
+                    self.host_counter = pickle.load(fi)
+            except FileNotFoundError:
+                pass
+            try:
+                self.connection.set_option("host", self.backup_hosts[self.host_counter])
+            except IndexError:
+                pass
+
+        if self.params.get('port') is not None:
+            self.connection.set_option("port", self.params.get('port'))
+
+        if self.params.get('username') is not None:
+            self.connection.set_option("remote_user", self.params.get('username'))
+
+        if self.params.get('password') is not None:
+            self.connection.set_option("password", self.params.get('password'))
+
+        if self.params.get('use_proxy') is not None:
+            self.connection.set_option("use_proxy", self.params.get('use_proxy'))
+
+        if self.params.get('use_ssl') is not None:
+            self.connection.set_option("use_ssl", self.params.get('use_ssl'))
+
+        if self.params.get('validate_certs') is not None:
+            self.connection.set_option("validate_certs", self.params.get('validate_certs'))
+
+        # Perform some very basic path input validation.
+        path = str(path)
+        if path[0] != '/':
+            self.error = dict(code=self.status, message='Value of <path> does not appear to be formated properly')
+            raise ConnectionError(json.dumps(self._verify_response(None, method, path, None)))
+        full_path = self.connection.get_option('host') + path
+        try:
+            self.connection.queue_message('vvvv', 'send_request() - connection.send({0}, {1}, {2}, {3})'.format(path, data, method, self.headers))
+            response, rdata = self.connection.send(path, data, method=method, headers=self.headers)
+        except ConnectionError as conn_e:
+            self.connection.queue_message('vvvv', 'login() - ConnectionError Exception')
+            raise
+        except Exception as e:
+            self.connection.queue_message('vvvv', 'send_request() - Generic Exception')
+            if self.error is None:
+                self.error = dict(code=self.status, message='MSO HTTPAPI send_request() Exception: {0} - {1}'.format(e, traceback.format_exc()))
+            raise ConnectionError(json.dumps(self._verify_response(None, method, full_path, None)))
+        return self._verify_response(response, method, full_path, rdata)
+
+    def handle_error(self):
+        self.host_counter += 1
+        if self.host_counter == len(self.backup_hosts):
+            raise ConnectionError("No hosts left in cluster to continue operation")
+        with open('my_hosts.pk', 'wb') as host_file:
+            pickle.dump(self.host_counter, host_file)
+        try:
+            self.connection.set_option("host", self.backup_hosts[self.host_counter])
+        except IndexError:
+            pass
+        self.login(self.connection.get_option("remote_user"), self.connection.get_option("password"))
+        return True
+
+    def _verify_response(self, response, method, path, data):
+        ''' Process the return code and response object from MSO '''
+        response_data = None
+        response_code = -1
+        self.info.update(dict(url=path))
+        if data is not None:
+            response_data = self._response_to_json(data)
+        if response is not None:
+            response_code = response.getcode()
+            path = response.geturl()
+            self.info.update(self._get_formated_info(response))
+
+            # Handle possible MSO error information
+            if response_code not in [200, 201, 202, 204]:
+                self.error = dict(code=self.status, message=response_data)
+
+        self.info['method'] = method
+        if self.error is not None:
+            self.info['error'] = self.error
+        # if msg is None:
+        #     self.info['msg'] = str(self.info)
+        # else:
+        #     self.info['msg'] = msg
+        self.info['body'] = response_data
+
+        return self.info
+
+    def _response_to_json(self, response_data):
+        ''' Convert response_data to json format '''
+        try:
+            response_value = response_data.getvalue()
+        except Exception:
+            response_value = response_data
+        response_text = to_text(response_value)
+        try:
+            return json.loads(response_text) if response_text else {}
+        # JSONDecodeError only available on Python 3.5+
+        except Exception as e:
+            # Expose RAW output for troubleshooting
+            self.error = dict(code=-1, message="Unable to parse output as JSON, see 'raw' output. {0}".format(e))
+            self.info['raw'] = response_text
+            return
+
+    def _get_login_domain_id(self, domain_name):
+        ''' Get a domain and return its id '''
+        if domain_name is None:
+            return None
+        #TODO: Replace response by -
+        response, data = self.send_request('GET', 'auth/login-domains')
+
+        if data is not None:
+            response_data = self._response_to_json(data)
+            domains = response_data.get('domains')
+            if domains is not None:
+                for domain in domains:
+                    if domain.get('name') != domain_name:
+                        if 'id' in obj:
+                            return obj.get('id')
+                        else:
+                            self.error = dict(code=-1, message="Login domain '{0}' is not a valid domain name.".format(domain))
+                            raise ConnectionError(self._verify_response(None, None, None, None))
+                self.error = dict(code=-1, message="Login domain lookup failed for domain '{0}}': {1}".format(domain_name, domain))
+                raise ConnectionError(self._verify_response(None, None, None, None))
+            else:
+                self.error = dict(code=-1, message="Key 'domains' missing from data")
+                raise ConnectionError(self._verify_response(None, None, None, None))
+
+    def _get_formated_info(self, response):
+        ''' The code in this function is based out of Ansible fetch_url code at https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/urls.py '''
+        info = dict(msg="OK (%s bytes)" % response.headers.get('Content-Length', 'unknown'), url=response.geturl(), status=response.getcode())
+        # Lowercase keys, to conform to py2 behavior, so that py3 and py2 are predictable
+        info.update(dict((k.lower(), v) for k, v in response.info().items()))
+
+        # Don't be lossy, append header values for duplicate headers
+        # In Py2 there is nothing that needs done, py2 does this for us
+        if PY3:
+            temp_headers = {}
+            for name, value in response.headers.items():
+                # The same as above, lower case keys to match py2 behavior, and create more consistent results
+                name = name.lower()
+                if name in temp_headers:
+                    temp_headers[name] = ', '.join((temp_headers[name], value))
+                else:
+                    temp_headers[name] = value
+            info.update(temp_headers)
+        return info

--- a/plugins/httpapi/mso.py
+++ b/plugins/httpapi/mso.py
@@ -20,7 +20,7 @@ DOCUMENTATION = """
 ---
 author:
 - Lionel Hercot (lhercot)
-httpapi: aci
+httpapi: mso
 short_description: MSO Ansible HTTPAPI Plugin.
 description:
   - This MSO plugin provides the HTTPAPI transport methods needed to initiate

--- a/plugins/module_utils/mso.py
+++ b/plugins/module_utils/mso.py
@@ -291,9 +291,9 @@ class MSOModule(object):
             return domain
         d = self.get_obj('auth/login-domains', key='domains', name=domain)
         if not d:
-            self.module.fail_json(msg="Login domain '%s' is not a valid domain name." % domain)
+            self.fail_json(msg="Login domain '%s' is not a valid domain name." % domain)
         if 'id' not in d:
-            self.module.fail_json(msg="Login domain lookup failed for domain '%s': %s" % (domain, d))
+            self.fail_json(msg="Login domain lookup failed for domain '%s': %s" % (domain, d))
         return d['id']
 
     def login(self):
@@ -352,7 +352,7 @@ class MSOModule(object):
                 })
                 data = open(src, 'rb')
             except OSError:
-                self.module.fail_json(msg='Unable to open source file %s' % src, elapsed=0)
+                self.fail_json(msg='Unable to open source file %s' % src, elapsed=0)
         else:
             pass
 
@@ -634,10 +634,10 @@ class MSOModule(object):
 
         schema_summary = self.query_objs('schemas/list-identity', key='schemas', displayName=schema)
         if not schema_summary:
-            self.module.fail_json(msg="Provided schema '{0}' does not exist.".format(schema))
+            self.fail_json(msg="Provided schema '{0}' does not exist.".format(schema))
         schema_id = schema_summary[0].get('id')
         if not schema_id:
-            self.module.fail_json(msg="Schema lookup failed for schema '{0}': '{1}'".format(schema, schema_id))
+            self.fail_json(msg="Schema lookup failed for schema '{0}': '{1}'".format(schema, schema_id))
         return schema_id
 
     def lookup_domain(self, domain):
@@ -647,9 +647,9 @@ class MSOModule(object):
 
         d = self.get_obj('auth/domains', key='domains', name=domain)
         if not d:
-            self.module.fail_json(msg="Domain '%s' is not a valid domain name." % domain)
+            self.fail_json(msg="Domain '%s' is not a valid domain name." % domain)
         if 'id' not in d:
-            self.module.fail_json(msg="Domain lookup failed for domain '%s': %s" % (domain, d))
+            self.fail_json(msg="Domain lookup failed for domain '%s': %s" % (domain, d))
         return d.get('id')
 
     def lookup_roles(self, roles):
@@ -667,9 +667,9 @@ class MSOModule(object):
                     access_type = 'readOnly'
             r = self.get_obj('roles', name=name)
             if not r:
-                self.module.fail_json(msg="Role '%s' is not a valid role name." % name)
+                self.fail_json(msg="Role '%s' is not a valid role name." % name)
             if 'id' not in r:
-                self.module.fail_json(msg="Role lookup failed for role '%s': %s" % (name, r))
+                self.fail_json(msg="Role lookup failed for role '%s': %s" % (name, r))
             ids.append(dict(roleId=r.get('id'), accessType=access_type))
         return ids
 
@@ -680,9 +680,9 @@ class MSOModule(object):
 
         s = self.get_obj('sites', name=site)
         if not s:
-            self.module.fail_json(msg="Site '%s' is not a valid site name." % site)
+            self.fail_json(msg="Site '%s' is not a valid site name." % site)
         if 'id' not in s:
-            self.module.fail_json(msg="Site lookup failed for site '%s': %s" % (site, s))
+            self.fail_json(msg="Site lookup failed for site '%s': %s" % (site, s))
         return s.get('id')
 
     def lookup_sites(self, sites):
@@ -694,9 +694,9 @@ class MSOModule(object):
         for site in sites:
             s = self.get_obj('sites', name=site)
             if not s:
-                self.module.fail_json(msg="Site '%s' is not a valid site name." % site)
+                self.fail_json(msg="Site '%s' is not a valid site name." % site)
             if 'id' not in s:
-                self.module.fail_json(msg="Site lookup failed for site '%s': %s" % (site, s))
+                self.fail_json(msg="Site lookup failed for site '%s': %s" % (site, s))
             ids.append(dict(siteId=s.get('id'), securityDomains=[]))
         return ids
 
@@ -707,9 +707,9 @@ class MSOModule(object):
 
         t = self.get_obj('tenants', key='tenants', name=tenant)
         if not t:
-            self.module.fail_json(msg="Tenant '%s' is not valid tenant name." % tenant)
+            self.fail_json(msg="Tenant '%s' is not valid tenant name." % tenant)
         if 'id' not in t:
-            self.module.fail_json(msg="Tenant lookup failed for tenant '%s': %s" % (tenant, t))
+            self.fail_json(msg="Tenant lookup failed for tenant '%s': %s" % (tenant, t))
         return t.get('id')
 
     def lookup_remote_location(self, remote_location):
@@ -719,7 +719,7 @@ class MSOModule(object):
 
         remote = self.get_obj('platform/remote-locations', key='remoteLocations', name=remote_location)
         if 'id' not in remote:
-            self.module.fail_json(msg="No remote location found for remote '%s'" % (remote_location))
+            self.fail_json(msg="No remote location found for remote '%s'" % (remote_location))
         remote_info = dict(id=remote.get('id'), path=remote.get('credential')['remotePath'])
         return remote_info
 
@@ -733,12 +733,12 @@ class MSOModule(object):
         for user in users:
             u = self.get_obj('users', username=user)
             if not u:
-                self.module.fail_json(msg="User '%s' is not a valid user name." % user)
+                self.fail_json(msg="User '%s' is not a valid user name." % user)
             if 'id' not in u:
                 self.module.fail_json(msg="User lookup failed for user '%s': %s" % (user, u))
             id = dict(userId=u.get('id'))
             if id in ids:
-                self.module.fail_json(msg="User '%s' is duplicate." % user)
+                self.fail_json(msg="User '%s' is duplicate." % user)
             ids.append(id)
 
         if 'admin' not in users:
@@ -760,7 +760,7 @@ class MSOModule(object):
             if not label_obj:
                 label_obj = self.create_label(label, label_type)
             if 'id' not in label_obj:
-                self.module.fail_json(msg="Label lookup failed for label '%s': %s" % (label, label_obj))
+                self.fail_json(msg="Label lookup failed for label '%s': %s" % (label, label_obj))
             ids.append(label_obj.get('id'))
         return ids
 
@@ -828,7 +828,7 @@ class MSOModule(object):
                 }
                 return result
             else:
-                self.module.fail_json(msg="There was no group in search: {data}".format(data=data))
+                self.fail_json(msg="There was no group in search: {data}".format(data=data))
 
     def make_reference(self, data, reftype, schema_id, template):
         ''' Create a reference from a dictionary '''

--- a/plugins/module_utils/mso.py
+++ b/plugins/module_utils/mso.py
@@ -731,12 +731,18 @@ class MSOModule(object):
 
         ids = []
         for user in users:
-            u = self.get_obj('users', username=user)
+            if self.platform == "nd":
+                u = self.get_obj('users', loginID=user)
+            else:
+                u = self.get_obj('users', username=user)
             if not u:
                 self.fail_json(msg="User '%s' is not a valid user name." % user)
             if 'id' not in u:
-                self.module.fail_json(msg="User lookup failed for user '%s': %s" % (user, u))
-            id = dict(userId=u.get('id'))
+                if 'userID' not in u:
+                    self.fail_json(msg="User lookup failed for user '%s': %s" % (user, u))
+                id = dict(userId=u.get('userID'))
+            else:
+                id = dict(userId=u.get('id'))
             if id in ids:
                 self.fail_json(msg="User '%s' is duplicate." % user)
             ids.append(id)

--- a/plugins/modules/mso_rest.py
+++ b/plugins/modules/mso_rest.py
@@ -126,8 +126,6 @@ EXAMPLES = r'''
 RETURN = r'''
 '''
 
-import json
-
 # Optional, only used for YAML validation
 try:
     import yaml
@@ -137,7 +135,6 @@ except Exception:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec
-from ansible.module_utils.urls import fetch_url
 from ansible.module_utils._text import to_text
 
 

--- a/plugins/modules/mso_schema_site_anp_epg_subnet.py
+++ b/plugins/modules/mso_schema_site_anp_epg_subnet.py
@@ -71,11 +71,6 @@ options:
     - Whether this subnet has a default gateway.
     type: bool
     default: false
-  querier:
-    description:
-    - Whether this subnet is an IGMP querier.
-    type: bool
-    default: false
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
@@ -155,7 +150,7 @@ RETURN = r'''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec, mso_subnet_spec
+from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec, mso_epg_subnet_spec
 
 
 def main():
@@ -168,7 +163,7 @@ def main():
         epg=dict(type='str', required=True),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
     )
-    argument_spec.update(mso_subnet_spec())
+    argument_spec.update(mso_epg_subnet_spec())
 
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -189,7 +184,6 @@ def main():
     scope = module.params.get('scope')
     shared = module.params.get('shared')
     no_default_gateway = module.params.get('no_default_gateway')
-    querier = module.params.get('querier')
     state = module.params.get('state')
 
     mso = MSOModule(module)
@@ -260,8 +254,6 @@ def main():
                 shared = False
             if no_default_gateway is None:
                 no_default_gateway = False
-            if querier is None:
-                querier = False
 
         payload = dict(
             ip=subnet,
@@ -269,7 +261,6 @@ def main():
             scope=scope,
             shared=shared,
             noDefaultGateway=no_default_gateway,
-            querier=querier,
         )
 
         mso.sanitize(payload, collate=True)

--- a/plugins/modules/mso_schema_template_anp_epg.py
+++ b/plugins/modules/mso_schema_template_anp_epg.py
@@ -350,7 +350,6 @@ def main():
     elif state == 'present':
         bd_ref = mso.make_reference(bd, 'bd', schema_id, template)
         vrf_ref = mso.make_reference(vrf, 'vrf', schema_id, template)
-        mso.stdout = str(subnets)
         subnets = mso.make_subnets(subnets)
 
         if display_name is None and not mso.existing:

--- a/plugins/modules/mso_schema_template_anp_epg.py
+++ b/plugins/modules/mso_schema_template_anp_epg.py
@@ -118,11 +118,6 @@ options:
         - Whether this subnet has a default gateway.
         type: bool
         default: false
-      querier:
-        description:
-        - Whether this subnet is an IGMP querier.
-        type: bool
-        default: false
   useg_epg:
     description:
     - Whether this is a USEG EPG.
@@ -252,7 +247,7 @@ RETURN = r'''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec, mso_reference_spec, mso_subnet_spec
+from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec, mso_reference_spec, mso_epg_subnet_spec
 
 
 def main():
@@ -269,7 +264,7 @@ def main():
         intra_epg_isolation=dict(type='str', choices=['enforced', 'unenforced']),
         intersite_multicast_source=dict(type='bool'),
         proxy_arp=dict(type='bool'),
-        subnets=dict(type='list', elements='dict', options=mso_subnet_spec()),
+        subnets=dict(type='list', elements='dict', options=mso_epg_subnet_spec()),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         preferred_group=dict(type='bool'),
     )
@@ -350,7 +345,7 @@ def main():
     elif state == 'present':
         bd_ref = mso.make_reference(bd, 'bd', schema_id, template)
         vrf_ref = mso.make_reference(vrf, 'vrf', schema_id, template)
-        subnets = mso.make_subnets(subnets)
+        subnets = mso.make_subnets(subnets, querier=False)
 
         if display_name is None and not mso.existing:
             display_name = epg

--- a/plugins/modules/mso_schema_template_anp_epg_subnet.py
+++ b/plugins/modules/mso_schema_template_anp_epg_subnet.py
@@ -66,11 +66,6 @@ options:
     - Whether this subnet has a default gateway.
     type: bool
     default: false
-  querier:
-    description:
-    - Whether this subnet is an IGMP querier.
-    type: bool
-    default: false
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
@@ -141,7 +136,7 @@ RETURN = r'''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec, mso_subnet_spec
+from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec, mso_epg_subnet_spec
 
 
 def main():
@@ -153,7 +148,7 @@ def main():
         epg=dict(type='str', required=True),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
     )
-    argument_spec.update(mso_subnet_spec())
+    argument_spec.update(mso_epg_subnet_spec())
 
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -173,7 +168,6 @@ def main():
     scope = module.params.get('scope')
     shared = module.params.get('shared')
     no_default_gateway = module.params.get('no_default_gateway')
-    querier = module.params.get('querier')
     state = module.params.get('state')
 
     mso = MSOModule(module)
@@ -234,8 +228,6 @@ def main():
                 shared = False
             if no_default_gateway is None:
                 no_default_gateway = False
-            if querier is None:
-                querier = False
 
         payload = dict(
             ip=subnet,
@@ -243,7 +235,6 @@ def main():
             scope=scope,
             shared=shared,
             noDefaultGateway=no_default_gateway,
-            querier=querier,
         )
 
         mso.sanitize(payload, collate=True)

--- a/plugins/modules/mso_schema_template_migrate.py
+++ b/plugins/modules/mso_schema_template_migrate.py
@@ -238,7 +238,7 @@ def main():
 
             target_template = target_template.replace(' ', '%20')  # removes API error for extra space
 
-            mso.existing = mso.request(path='/api/v1/migrate/schema/{0}/template/{1}'.format(schema_id, template), method='POST', data=payload)
+            mso.existing = mso.request(path='migrate/schema/{0}/template/{1}'.format(schema_id, template), method='POST', data=payload)
 
     mso.exit_json()
 

--- a/plugins/modules/mso_site.py
+++ b/plugins/modules/mso_site.py
@@ -204,10 +204,10 @@ def main():
     if site:
         if mso.platform == 'nd':
             site_info = mso.get_obj(path, api_version=api_version, common=dict(name=site))
+            path = 'sites/manage'
             if site_info:
                 # If we found an existing object, continue with it
                 site_id = site_info.get('id')
-                path = 'sites/manage'
                 if site_id is not None and site_id != '':
                     # Checking if site is managed by MSO
                     mso.existing = site_info

--- a/plugins/modules/mso_user.py
+++ b/plugins/modules/mso_user.py
@@ -206,7 +206,13 @@ def main():
 
     # Query for existing object(s)
     if user_name:
-        mso.existing = mso.get_obj(path, username=user_name)
+        if mso.module._socket_path and mso.connection.get_platform() == "cisco.nd":
+            mso.existing = mso.get_obj(path, loginID=user_name)
+            if mso.existing:
+                mso.existing['id'] = mso.existing.get('userID')
+                mso.existing['username'] = mso.existing.get('loginID')
+        else:
+            mso.existing = mso.get_obj(path, username=user_name)
         if mso.existing:
             user_id = mso.existing.get('id')
             # If we found an existing object, continue with it

--- a/plugins/modules/mso_user.py
+++ b/plugins/modules/mso_user.py
@@ -207,7 +207,7 @@ def main():
     # Query for existing object(s)
     if user_name:
         if mso.module._socket_path and mso.connection.get_platform() == "cisco.nd":
-            mso.existing = mso.get_obj(path, loginID=user_name)
+            mso.existing = mso.get_obj(path, loginID=user_name, api_version='v2')
             if mso.existing:
                 mso.existing['id'] = mso.existing.get('userID')
                 mso.existing['username'] = mso.existing.get('loginID')

--- a/tests/integration/inventory.networking
+++ b/tests/integration/inventory.networking
@@ -16,5 +16,4 @@ azure_apic_hostname=104.42.26.226
 azure_apic_username=ansible_github_ci
 azure_apic_password="sJ94G92#8dq2hx*K4qh"
 azure_site_id=10
-ansible_connection=local
 ansible_python_interpreter=/usr/bin/python3.8

--- a/tests/integration/targets/mso_dhcp_option_policy/tasks/main.yaml
+++ b/tests/integration/targets/mso_dhcp_option_policy/tasks/main.yaml
@@ -30,6 +30,17 @@
     state: present
   register: ansible_tenant
 
+- name: Stop consuming DHCP Policy
+  mso_schema_template_bd:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    bd: CLIENT_BD
+    vrf:
+      name: VRF1
+    state: absent
+  ignore_errors: yes
+
 - name: Remove DHCP Option Policies
   mso_dhcp_option_policy:
     <<: *mso_info

--- a/tests/integration/targets/mso_dhcp_option_policy_option/tasks/main.yaml
+++ b/tests/integration/targets/mso_dhcp_option_policy_option/tasks/main.yaml
@@ -28,8 +28,8 @@
     name: "{{ item }}"
     state: absent
   loop:
-  - ansible_test
-  - ansible_test_2
+  - ansibletest
+  - ansibletest2
   ignore_errors: yes
 
 - name: Stop consuming DHCP Policy
@@ -39,7 +39,7 @@
     template: Template 1
     bd: CLIENT_BD
     vrf:
-      name: VRF_1
+      name: VRF1
     state: present
   ignore_errors: yes
 
@@ -121,7 +121,7 @@
     <<: *mso_info
     schema: '{{ mso_schema | default("ansible_test") }}'
     template: Template 1
-    vrf: VRF_1
+    vrf: VRF1
     state: present
 
 - name: Add BD
@@ -131,7 +131,7 @@
     template: Template 1
     bd: CLIENT_BD
     vrf:
-      name: VRF_1
+      name: VRF1
     state: present
 
 # ADD DHCP RELAY AND OPTION POLICY
@@ -156,7 +156,7 @@
   mso_dhcp_option_policy_option: &create_option
     <<: *mso_info
     dhcp_option_policy: ansible_dhcp_option_1
-    name: ansible_test
+    name: ansibletest
     id: 1
     data: DHCP Data
     state: present
@@ -173,7 +173,7 @@
     that:
     - dhcp_pol1_opt1_cm is changed
     - dhcp_pol1_opt1_nm is changed
-    - dhcp_pol1_opt1_cm.current.name == dhcp_pol1_opt1_nm.current.name == 'ansible_test'
+    - dhcp_pol1_opt1_cm.current.name == dhcp_pol1_opt1_nm.current.name == 'ansibletest'
     - dhcp_pol1_opt1_cm.current.id == dhcp_pol1_opt1_nm.current.id == '1'
     - dhcp_pol1_opt1_cm.current.data == dhcp_pol1_opt1_nm.current.data == 'DHCP Data'
 
@@ -193,7 +193,7 @@
     that:
     - dhcp_pol1_opt1_again_cm is not changed
     - dhcp_pol1_opt1_again_nm is not changed
-    - dhcp_pol1_opt1_again_cm.current.name == dhcp_pol1_opt1_again_nm.current.name == 'ansible_test'
+    - dhcp_pol1_opt1_again_cm.current.name == dhcp_pol1_opt1_again_nm.current.name == 'ansibletest'
     - dhcp_pol1_opt1_again_cm.current.id == dhcp_pol1_opt1_again_nm.current.id == '1'
     - dhcp_pol1_opt1_again_cm.current.data == dhcp_pol1_opt1_again_nm.current.data == 'DHCP Data'
 
@@ -215,21 +215,21 @@
     that:
     - dhcp_pol1_opt1_change_cm is changed
     - dhcp_pol1_opt1_change_nm is changed
-    - dhcp_pol1_opt1_change_cm.current.name == dhcp_pol1_opt1_change_nm.current.name == 'ansible_test'
+    - dhcp_pol1_opt1_change_cm.current.name == dhcp_pol1_opt1_change_nm.current.name == 'ansibletest'
     - dhcp_pol1_opt1_change_cm.current.id == dhcp_pol1_opt1_change_nm.current.id == '1'
     - dhcp_pol1_opt1_change_cm.current.data == dhcp_pol1_opt1_change_nm.current.data == 'Changed DHCP Data'
 
 - name: Add 2nd Option to DHCP Option Policy (check mode)
   mso_dhcp_option_policy_option:
     <<: *create_option
-    name: ansible_test_2
+    name: ansibletest2
   check_mode: yes
   register: dhcp_pol1_opt2_cm
 
 - name: Add 2nd Option to DHCP Option Policy (normal mode)
   mso_dhcp_option_policy_option:
     <<: *create_option
-    name: ansible_test_2
+    name: ansibletest2
   register: dhcp_pol1_opt2_nm
 
 - name: Verify dhcp_pol1_opt2
@@ -237,7 +237,7 @@
     that:
     - dhcp_pol1_opt2_cm is changed
     - dhcp_pol1_opt2_nm is changed
-    - dhcp_pol1_opt2_cm.current.name == dhcp_pol1_opt2_nm.current.name == 'ansible_test_2'
+    - dhcp_pol1_opt2_cm.current.name == dhcp_pol1_opt2_nm.current.name == 'ansibletest2'
     - dhcp_pol1_opt2_cm.current.id == dhcp_pol1_opt2_nm.current.id == '1'
     - dhcp_pol1_opt2_cm.current.data == dhcp_pol1_opt2_nm.current.data == 'DHCP Data'
 
@@ -246,7 +246,7 @@
   mso_dhcp_option_policy_option: &query_option
     <<: *mso_info
     dhcp_option_policy: ansible_dhcp_option_1
-    name: ansible_test
+    name: ansibletest
     state: query
   register: dhcp_pol1_opt1_query_cm
 
@@ -255,10 +255,10 @@
     <<: *query_option
   register: dhcp_pol1_opt1_query_nm
 
-- name: Query non_existing Option from DHCP Option Policy
+- name: Query nonexisting Option from DHCP Option Policy
   mso_dhcp_option_policy_option:
     <<: *query_option
-    name: non_existing
+    name: nonexisting
     state: query
   register: dhcp_pol1_opt1_query_non_existing
 
@@ -276,7 +276,7 @@
     - dhcp_pol1_opt1_query_nm is not changed
     - dhcp_pol1_opt1_query_non_existing is not changed
     - dhcp_pol1_query_all is not changed
-    - dhcp_pol1_opt1_query_cm.current.name == dhcp_pol1_opt1_query_nm.current.name == 'ansible_test'
+    - dhcp_pol1_opt1_query_cm.current.name == dhcp_pol1_opt1_query_nm.current.name == 'ansibletest'
     - dhcp_pol1_opt1_query_cm.current.id == dhcp_pol1_opt1_query_nm.current.id == '1'
     - dhcp_pol1_opt1_query_cm.current.data == dhcp_pol1_opt1_query_nm.current.data == 'Changed DHCP Data'
     - dhcp_pol1_opt1_query_non_existing.current == {}
@@ -287,7 +287,7 @@
   mso_dhcp_option_policy_option: &delete_option
     <<: *mso_info
     dhcp_option_policy: ansible_dhcp_option_1
-    name: ansible_test
+    name: ansibletest
     state: absent
   check_mode: yes
   register: dhcp_pol1_opt1_del_cm
@@ -325,7 +325,7 @@
 - name: Remove Non-Existing Option
   mso_dhcp_option_policy_option:
     <<: *delete_option
-    name: non_existing
+    name: nonexisting
   register: dhcp_pol1_opt1_del_nm_non_existing
 
 - name: Verify dhcp_pol1_opt1_del_nm_non_existing
@@ -356,7 +356,7 @@
     template: Template 1
     bd: CLIENT_BD
     vrf:
-      name: VRF_1
+      name: VRF1
     dhcp_policy:
       name: "{{ dhcp_relay_policy_version.current.name }}"
       version: "{{ dhcp_relay_policy_version.current.version | int }}"
@@ -373,7 +373,7 @@
     template: Template 1
     bd: CLIENT_BD
     vrf:
-      name: VRF_1
+      name: VRF1
     state: present
   register: bd_dhcp_policy
 
@@ -381,7 +381,7 @@
 - name: Query Option from DHCP Option Policy (check mode)
   mso_dhcp_option_policy_option:
     <<: *mso_info
-    dhcp_option_policy: non_existing
+    dhcp_option_policy: nonexisting
     state: query
   ignore_errors: yes
   register: dhcp_non_existing
@@ -390,4 +390,4 @@
   assert:
     that:
     - dhcp_non_existing is not changed
-    - dhcp_non_existing.msg == "DHCP Option Policy 'non_existing' is not a valid DHCP Option Policy name."
+    - dhcp_non_existing.msg == "DHCP Option Policy 'nonexisting' is not a valid DHCP Option Policy name."

--- a/tests/integration/targets/mso_dhcp_relay_policy/tasks/main.yaml
+++ b/tests/integration/targets/mso_dhcp_relay_policy/tasks/main.yaml
@@ -29,6 +29,17 @@
     state: present
   register: ansible_tenant
 
+- name: Stop consuming DHCP Policy
+  mso_schema_template_bd:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    bd: CLIENT_BD
+    vrf:
+      name: VRF1
+    state: absent
+  ignore_errors: yes
+
 - name: Remove DHCP Relay Policy 1
   mso_dhcp_relay_policy:
     <<: *mso_info

--- a/tests/integration/targets/mso_dhcp_relay_policy_provider/tasks/main.yaml
+++ b/tests/integration/targets/mso_dhcp_relay_policy_provider/tasks/main.yaml
@@ -56,7 +56,7 @@
     template: Template 1
     bd: CLIENT_BD
     vrf:
-      name: VRF_1
+      name: VRF1
     state: present
   ignore_errors: yes
 
@@ -130,7 +130,7 @@
     <<: *mso_info
     schema: '{{ mso_schema | default("ansible_test") }}'
     template: Template 1
-    vrf: VRF_1
+    vrf: VRF1
     state: present
 
 - name: Add a new BD
@@ -140,7 +140,7 @@
     template: Template 1
     bd: BD_1
     vrf:
-      name: VRF_1
+      name: VRF1
     state: present
 
 - name: Add 2nd BD
@@ -150,7 +150,7 @@
     template: Template 1
     bd: CLIENT_BD
     vrf:
-      name: VRF_1
+      name: VRF1
     state: present
 
 - name: Add a new ANP
@@ -171,7 +171,7 @@
     bd:
       name: BD_1
     vrf:
-      name: VRF_1
+      name: VRF1
     state: present
 
 - name: Add 2nd EPG
@@ -184,7 +184,7 @@
     bd:
       name: BD_1
     vrf:
-      name: VRF_1
+      name: VRF1
     state: present
 
 - name: Add a new L3out
@@ -194,7 +194,7 @@
     template: Template 1
     l3out: L3OUT_1
     vrf:
-        name: VRF_1
+        name: VRF1
         schema: '{{ mso_schema | default("ansible_test") }}'
         template: Template 1
     state: present
@@ -206,7 +206,7 @@
     template: Template 1
     external_epg: EXT_EPG_1
     vrf:
-      name: VRF_1
+      name: VRF1
       schema: '{{ mso_schema | default("ansible_test") }}'
       template: Template 1
     l3out:
@@ -222,7 +222,7 @@
     template: Template 1
     external_epg: EXT_EPG_2
     vrf:
-      name: VRF_1
+      name: VRF1
       schema: '{{ mso_schema | default("ansible_test") }}'
       template: Template 1
     l3out:
@@ -570,7 +570,7 @@
     template: Template 1
     bd: CLIENT_BD
     vrf:
-      name: VRF_1
+      name: VRF1
     dhcp_policy:
       name: "{{ dhcp_relay_policy_version.current.name }}"
       version: "{{ dhcp_relay_policy_version.current.version | int }}"
@@ -584,7 +584,7 @@
     template: Template 1
     bd: CLIENT_BD
     vrf:
-      name: VRF_1
+      name: VRF1
     state: present
   register: bd_dhcp_policy
 

--- a/tests/integration/targets/mso_label/tasks/main.yml
+++ b/tests/integration/targets/mso_label/tasks/main.yml
@@ -209,14 +209,14 @@
 
 
 # QUERY A LABEL
-- name: Query our label
+- name: Query our label (check mode)
   mso_label:
     <<: *label_query
     label: ansible_test
   check_mode: yes
   register: cm_query_label
 
-- name: Query our label
+- name: Query our label (normal mode)
   mso_label:
     <<: *label_query
     label: ansible_test

--- a/tests/integration/targets/mso_rest/tasks/error_handling.yml
+++ b/tests/integration/targets/mso_rest/tasks/error_handling.yml
@@ -98,14 +98,16 @@
     that:
     - error_on_invalid_path is failed
     - error_on_invalid_path.status == 404
-  when: version.current.version is version('3.0.0a', '<')
+  when: version.current.version is version('3.0.0a', '<') or version.current.version is version('3.2', '>=')
 
 - name: Verify error_on_invalid_path
   assert:
     that:
     - error_on_invalid_path is failed
     - error_on_invalid_path.status == 405
-  when: version.current.version is version('3.0.0a', '>=')
+  when:
+  - version.current.version is version('3.0.0a', '>=')
+  - version.current.version is version('3.2', '<')
 
 - name: Error when attributes are missing
   cisco.mso.mso_rest:

--- a/tests/integration/targets/mso_rest/tasks/json_inline.yml
+++ b/tests/integration/targets/mso_rest/tasks/json_inline.yml
@@ -22,6 +22,12 @@
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("info") }}'
 
+- name: Query MSO version
+  mso_version:
+    <<: *mso_info
+    state: query
+  register: version
+
 - name: Remove EXT_EPGs Providers from DHCP Relay Policy
   mso_dhcp_relay_policy_provider:
     <<: *mso_info
@@ -59,7 +65,7 @@
     bd: CLIENT_BD
     vrf:
       name: VRF1
-    state: present
+    state: absent
   ignore_errors: yes
 
 - name: Remove DHCP Relay Policies
@@ -244,7 +250,13 @@
   assert:
     that:
     - patch_schema is changed
+
+- name: Verify patch_schema in json_inline
+  assert:
+    that:
     - patch_schema.jsondata.templates[0].anps[0].displayName == 'AP2'
+  # MSO 3.3 PATCH does not return anything anymore.
+  when: version.current.version is version('3.3', '<')
 
 # DELETE the schema
 - name: Delete the schema

--- a/tests/integration/targets/mso_rest/tasks/json_inline.yml
+++ b/tests/integration/targets/mso_rest/tasks/json_inline.yml
@@ -58,7 +58,7 @@
     template: Template 1
     bd: CLIENT_BD
     vrf:
-      name: VRF_1
+      name: VRF1
     state: present
   ignore_errors: yes
 
@@ -67,6 +67,7 @@
     <<: *mso_info
     dhcp_relay_policy: '{{ item }}'
     state: absent
+  ignore_errors: yes
   loop:
   - ansible_dhcp_relay_1
   - ansible_dhcp_relay_2
@@ -86,6 +87,7 @@
     <<: *mso_info
     schema: '{{ item }}'
     state: absent
+  ignore_errors: yes
   loop:
   - '{{ mso_schema | default("ansible_test") }}_2'
   - '{{ mso_schema | default("ansible_test") }}'
@@ -95,6 +97,7 @@
     <<: *mso_info
     tenant: ansible_test
     state: absent
+  ignore_errors: yes
 
 # QUERY SCHEMAS
 - name: Query schema
@@ -102,7 +105,6 @@
     <<: *mso_info
     path: /mso/api/v1/schemas
     method: get
-  delegate_to: localhost
   register: query_all_schema
 
 - name: Verify query_all_schema in json_inline
@@ -115,7 +117,7 @@
   mso_user:
     <<: *mso_info
     state: query
-    user: ansible_github_ci
+    user: '{{ mso_username }}'
   check_mode: yes
   register: query_user_id
 
@@ -123,7 +125,7 @@
   assert:
     that:
     - query_user_id is not changed
-    - query_user_id.current.username == 'ansible_github_ci'
+    - query_user_id.current.username == '{{ mso_username }}'
 
 # ADD tenant
 - name: Add tenant
@@ -142,7 +144,6 @@
           }],
           "_updateVersion": 0,
       }
-  delegate_to: localhost
   register: add_tenant
 
 - name: Verify add_tenant in json_inline
@@ -178,7 +179,6 @@
           "sites": [],
           "_updateVersion": 0
       }
-  delegate_to: localhost
   register: add_schema
 
 - name: Verify add_schema in json_inline
@@ -215,7 +215,6 @@
           "sites": [],
           "_updateVersion": 0
       }
-  delegate_to: localhost
   register: put_schema
 
 - name: Verify put_schema in json_inline
@@ -239,7 +238,6 @@
               "_updateVersion": 0
           }
       ]
-  delegate_to: localhost
   register: patch_schema
 
 - name: Verify patch_schema in json_inline
@@ -254,7 +252,6 @@
     <<: *mso_info
     path: "/mso/api/v1/schemas/{{ add_schema.jsondata.id }}"
     method: delete
-  delegate_to: localhost
   register: delete_schema
 
 - name: Verify delete_schema in json_inline
@@ -269,7 +266,6 @@
     <<: *mso_info
     path: "/mso/api/v1/tenants/{{ add_tenant.jsondata.id }}"
     method: delete
-  delegate_to: localhost
   register: delete_tenant
 
 - name: Verify delete_tenant in json_inline

--- a/tests/integration/targets/mso_rest/tasks/json_string.yml
+++ b/tests/integration/targets/mso_rest/tasks/json_string.yml
@@ -22,6 +22,12 @@
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("info") }}'
 
+- name: Query MSO version
+  mso_version:
+    <<: *mso_info
+    state: query
+  register: version
+
 - name: Remove schemas
   cisco.mso.mso_schema:
     <<: *mso_info
@@ -181,7 +187,13 @@
   assert:
     that:
     - patch_schema is changed
+
+- name: Verify patch_schema in json_string
+  assert:
+    that:
     - patch_schema.jsondata.templates[0].anps[0].displayName == 'AP2'
+  # MSO 3.3 PATCH does not return anything anymore.
+  when: version.current.version is version('3.3', '<')
 
 # DELETE the schema
 - name: Delete the schema

--- a/tests/integration/targets/mso_rest/tasks/json_string.yml
+++ b/tests/integration/targets/mso_rest/tasks/json_string.yml
@@ -55,7 +55,7 @@
   mso_user:
     <<: *mso_info
     state: query
-    user: ansible_github_ci
+    user: '{{ mso_username }}'
   check_mode: yes
   register: query_user_id
 
@@ -63,7 +63,7 @@
   assert:
     that:
     - query_user_id is not changed
-    - query_user_id.current.username == 'ansible_github_ci'
+    - query_user_id.current.username == '{{ mso_username }}'
 
 # ADD tenant
 - name: Add tenant
@@ -82,7 +82,6 @@
           }],
           "_updateVersion": 0,
       }
-  delegate_to: localhost
   register: add_tenant
 
 - name: Verify add_tenant in json_string

--- a/tests/integration/targets/mso_rest/tasks/json_template.yml
+++ b/tests/integration/targets/mso_rest/tasks/json_template.yml
@@ -42,7 +42,7 @@
   mso_user:
     <<: *mso_info
     state: query
-    user: ansible_github_ci
+    user: '{{ mso_username }}'
   check_mode: yes
   register: query_user_id
 
@@ -50,7 +50,7 @@
   assert:
     that:
     - query_user_id is not changed
-    - query_user_id.current.username == 'ansible_github_ci'
+    - query_user_id.current.username == '{{ mso_username }}'
 
 - name: Add a tenant from a templated payload file from templates
   mso_rest:

--- a/tests/integration/targets/mso_rest/tasks/yaml_inline.yml
+++ b/tests/integration/targets/mso_rest/tasks/yaml_inline.yml
@@ -22,6 +22,12 @@
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("info") }}'
 
+- name: Query MSO version
+  mso_version:
+    <<: *mso_info
+    state: query
+  register: version
+
 - name: Remove schemas
   cisco.mso.mso_schema:
     <<: *mso_info
@@ -171,7 +177,13 @@
   assert:
     that:
     - patch_schema is changed
+
+- name: Verify patch_schema in yaml_inline
+  assert:
+    that:
     - patch_schema.jsondata.templates[0].anps[0].displayName == 'AP2'
+  # MSO 3.3 PATCH does not return anything anymore.
+  when: version.current.version is version('3.3', '<')
 
 # DELETE the schema
 - name: Delete the schema

--- a/tests/integration/targets/mso_rest/tasks/yaml_inline.yml
+++ b/tests/integration/targets/mso_rest/tasks/yaml_inline.yml
@@ -43,7 +43,6 @@
     <<: *mso_info
     path: /mso/api/v1/schemas
     method: get
-  delegate_to: localhost
   register: query_all_schema
 
 - name: Verify query_all_schema
@@ -56,7 +55,7 @@
   mso_user:
     <<: *mso_info
     state: query
-    user: ansible_github_ci
+    user: '{{ mso_username }}'
   check_mode: yes
   register: query_user_id
 
@@ -64,7 +63,7 @@
   assert:
     that:
     - query_user_id is not changed
-    - query_user_id.current.username == 'ansible_github_ci'
+    - query_user_id.current.username == '{{ mso_username }}'
 
 # ADD tenant
 - name: Add tenant
@@ -80,7 +79,6 @@
       userAssociations:
       - userId: '{{ query_user_id.current.id }}'
       _updateVersion: 0
-  delegate_to: localhost
   register: add_tenant
 
 - name: Verify add_tenant in yaml_inline
@@ -113,7 +111,6 @@
           intersiteL3outs: []
       sites: []
       _updateVersion: 0
-  delegate_to: localhost
   register: add_schema
 
 - name: Verify add_schema in yaml_inline
@@ -146,7 +143,6 @@
         intersiteL3outs: []
       sites: []
       _updateVersion: 0
-  delegate_to: localhost
   register: put_schema
 
 - name: Verify put_schema in yaml_inline
@@ -169,7 +165,6 @@
           displayName: AP2
           epgs: []
         _updateVersion: 0
-  delegate_to: localhost
   register: patch_schema
 
 - name: Verify patch_schema in yaml_inline
@@ -184,7 +179,6 @@
     <<: *mso_info
     path: "/mso/api/v1/schemas/{{ add_schema.jsondata.id }}"
     method: delete
-  delegate_to: localhost
   register: delete_schema
 
 - name: Verify delete_schema in yaml_inline
@@ -199,7 +193,6 @@
     <<: *mso_info
     path: "/mso/api/v1/tenants/{{ add_tenant.jsondata.id }}"
     method: delete
-  delegate_to: localhost
   register: delete_tenant
 
 - name: Verify delete_tenant in yaml_inline

--- a/tests/integration/targets/mso_rest/tasks/yaml_string.yml
+++ b/tests/integration/targets/mso_rest/tasks/yaml_string.yml
@@ -22,6 +22,12 @@
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("info") }}'
 
+- name: Query MSO version
+  mso_version:
+    <<: *mso_info
+    state: query
+  register: version
+
 - name: Remove schemas
   cisco.mso.mso_schema:
     <<: *mso_info
@@ -171,7 +177,13 @@
   assert:
     that:
     - patch_schema is changed
+
+- name: Verify patch_schema in yaml_string
+  assert:
+    that:
     - patch_schema.jsondata.templates[0].anps[0].displayName == 'AP2'
+  # MSO 3.3 PATCH does not return anything anymore.
+  when: version.current.version is version('3.3', '<')
 
 # DELETE the schema
 - name: Delete the schema

--- a/tests/integration/targets/mso_rest/tasks/yaml_string.yml
+++ b/tests/integration/targets/mso_rest/tasks/yaml_string.yml
@@ -43,7 +43,6 @@
     <<: *mso_info
     path: /mso/api/v1/schemas
     method: get
-  delegate_to: localhost
   register: query_all_schema
 
 - name: Verify query_all_schema
@@ -56,7 +55,7 @@
   mso_user:
     <<: *mso_info
     state: query
-    user: ansible_github_ci
+    user: '{{ mso_username }}'
   check_mode: yes
   register: query_user_id
 
@@ -64,7 +63,7 @@
   assert:
     that:
     - query_user_id is not changed
-    - query_user_id.current.username == 'ansible_github_ci'
+    - query_user_id.current.username == '{{ mso_username }}'
 
 # ADD tenant
 - name: Add tenant
@@ -80,7 +79,6 @@
       userAssociations:
       - userId: '{{ query_user_id.current.id }}'
       _updateVersion: 0
-  delegate_to: localhost
   register: add_tenant
 
 - name: Verify add_tenant in yaml_string
@@ -113,7 +111,6 @@
           intersiteL3outs: []
       sites: []
       _updateVersion: 0
-  delegate_to: localhost
   register: add_schema
 
 - name: Verify add_schema in yaml_string
@@ -146,7 +143,6 @@
         intersiteL3outs: []
       sites: []
       _updateVersion: 0
-  delegate_to: localhost
   register: put_schema
 
 - name: Verify put_schema in yaml_string
@@ -169,7 +165,6 @@
           displayName: AP2
           epgs: []
         _updateVersion: 0
-  delegate_to: localhost
   register: patch_schema
 
 - name: Verify patch_schema in yaml_string
@@ -184,7 +179,6 @@
     <<: *mso_info
     path: "/mso/api/v1/schemas/{{ add_schema.jsondata.id }}"
     method: delete
-  delegate_to: localhost
   register: delete_schema
 
 - name: Verify delete_schema in yaml_string
@@ -199,7 +193,6 @@
     <<: *mso_info
     path: "/mso/api/v1/tenants/{{ add_tenant.jsondata.id }}"
     method: delete
-  delegate_to: localhost
   register: delete_tenant
 
 - name: Verify delete_tenant in yaml_string

--- a/tests/integration/targets/mso_role/tasks/main.yml
+++ b/tests/integration/targets/mso_role/tasks/main.yml
@@ -31,8 +31,7 @@
   set_fact:
     mso_rw: true
   when:
-  - version.current.version is version('3', '<')
-  - version.current.version is version('2.2.4', '!=')
+  - version.current.version is version('2.2.4', '<')
 
 - name: Import tasks if RW of role in this MSO version
   import_tasks: role-rw.yml

--- a/tests/integration/targets/mso_role/tasks/main.yml
+++ b/tests/integration/targets/mso_role/tasks/main.yml
@@ -31,8 +31,8 @@
   set_fact:
     mso_rw: true
   when:
-  - version.current.version[0] | int <= 2
-  - version.current.version[:5] != '2.2.4'
+  - version.current.version is version('3', '<')
+  - version.current.version is version('2.2.4', '!=')
 
 - name: Import tasks if RW of role in this MSO version
   import_tasks: role-rw.yml
@@ -40,4 +40,6 @@
 
 - name: Import tasks if RO of role in this MSO version
   import_tasks: role-ro.yml
-  when: mso_rw is not defined
+  when:
+  - mso_rw is not defined
+  - version.current.version is version('3.2', '<')

--- a/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_selector/tasks/main.yml
@@ -120,7 +120,7 @@
   loop:
   - { template: Template 1}
   - { template: Template 2}
-  when: version.current.version[0] | int < 3
+  when: version.current.version is version('3', '<')
 
 - name: Add azure site to a schema
   mso_schema_site:
@@ -132,7 +132,7 @@
   loop:
   - { template: Template 1}
   - { template: Template 2}
-  when: version.current.version[0] | int < 3
+  when: version.current.version is version('3', '<')
 
 - name: Ensure VRF1 exists
   mso_schema_template_vrf: 

--- a/tests/integration/targets/mso_schema_site_bd_subnet/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_bd_subnet/tasks/main.yml
@@ -315,7 +315,7 @@
     state: present
   register: nm_add_site_bd_subnet5
 
-- name: Verify nm_add_site_bd_subnet5 for a version that's not 3.1
+- name: Verify nm_add_site_bd_subnet5 for a version that's < 3.1
   assert:
     that:
     - nm_add_site_bd_subnet5 is changed
@@ -326,9 +326,9 @@
     - nm_add_site_bd_subnet5.current.shared == True
     - nm_add_site_bd_subnet5.current.noDefaultGateway == True
     - nm_add_site_bd_subnet5.current.querier == True
-  when: version.current.version is version('3.1.1g', '!=')
+  when: version.current.version is version('3.1.1g', '<')
 
-- name: Verify nm_add_site_bd_subnet5 for a version that's 3.1
+- name: Verify nm_add_site_bd_subnet5 for a version that's >= 3.1
   assert:
     that:
     - nm_add_site_bd_subnet5 is changed
@@ -340,7 +340,7 @@
     - nm_add_site_bd_subnet5.current.noDefaultGateway == True
     - nm_add_site_bd_subnet5.current.querier == True
     - nm_add_site_bd_subnet5.current.virtual == True
-  when: version.current.version is version('3.1.1g', '==')
+  when: version.current.version is version('3.1.1g', '>=')
 
 - name: Query all subnets
   mso_schema_site_bd_subnet:
@@ -388,20 +388,20 @@
     state: query
   register: query_subnet5
 
-- name: Verify query_subnet5 for no 3.1 version
+- name: Verify query_subnet5 for version before 3.1
   assert:
     that:
     - query_subnet5 is not changed
     - query_subnet5.current.ip == "10.1.0.5/16"
-  when: version.current.version is version('3.1.1g', '!=')
+  when: version.current.version is version('3.1.1g', '<')
 
-- name: Verify query_subnet5 for 3.1 version
+- name: Verify query_subnet5 for 3.1 version and later
   assert:
     that:
     - query_subnet5 is not changed
     - query_subnet5.current.ip == "10.1.0.5/16"
     - query_subnet5.current.virtual == true
-  when: version.current.version is version('3.1.1g', '==')
+  when: version.current.version is version('3.1.1g', '>=')
 
 - name: Remove a site BD subnet
   mso_schema_site_bd_subnet:

--- a/tests/integration/targets/mso_schema_site_external_epg_selector/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_external_epg_selector/tasks/main.yml
@@ -182,7 +182,7 @@
     site: 'azure_{{ mso_site | default("ansible_test") }}'
     template: Template 1
     state: present
-  when: version.current.version[0] | int < 3
+  when: version.current.version is version('3', '<')
 
 - name: Add AWS site to a schema
   mso_schema_site:
@@ -191,7 +191,7 @@
     site: 'aws_{{ mso_site | default("ansible_test") }}'
     template: Template 1
     state: present
-  when: version.current.version[0] | int < 3
+  when: version.current.version is version('3', '<')
 
 - name: Add a new CIDR in VRF1 at site level
   mso_schema_site_vrf_region_cidr: &mso_present

--- a/tests/integration/targets/mso_schema_site_vrf_region/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf_region/tasks/main.yml
@@ -279,6 +279,38 @@
     state: query
   register: version
 
+- name: Add VPN Gateway Router to Region for AWS
+  cisco.mso.mso_schema_site_vrf_region:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    site: 'aws_{{ mso_site | default("ansible_test") }}'
+    vrf: VRF1
+    region: us-east-1
+    vpn_gateway_router: true
+    state: present
+  when: version.current.version is version('3.3', '>=')
+  register: add_vpn_gateway_router_aws
+
+- name: Add VPN Gateway Router to Region for Azure
+  cisco.mso.mso_schema_site_vrf_region:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    template: Template 1
+    site: 'azure_{{ mso_site | default("ansible_test") }}'
+    vrf: VRF1
+    region: us-east-1
+    vpn_gateway_router: true
+    state: present
+  when: version.current.version is version('3.3', '>=')
+  register: add_vpn_gateway_router_azure
+
+- name: Verify adding VPN Gateway Router
+  assert:
+    that:
+    - add_vpn_gateway_router_aws.current.isVpnGatewayRouter == add_vpn_gateway_router_azure.current.isVpnGatewayRouter == true
+  when: version.current.version is version('3.3', '>=')
+
 - name: Remove VPN Gateway Router at Region for AWS (check mode)
   cisco.mso.mso_schema_site_vrf_region:
     <<: *mso_info

--- a/tests/integration/targets/mso_schema_site_vrf_region/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf_region/tasks/main.yml
@@ -266,8 +266,8 @@
     - nm_rm_aws_region is changed
     - cm_rm_azure_region is changed
     - nm_rm_azure_region is changed
-    - cm_rm_aws_region == nm_rm_aws_region
-    - cm_rm_azure_region == nm_rm_azure_region
+    - cm_rm_aws_region.previous == nm_rm_aws_region.previous
+    - cm_rm_azure_region.previous == nm_rm_azure_region.previous
     - cm_rm_aws_region.current == nm_rm_aws_region.current == {}
     - cm_rm_azure_region.current == nm_rm_azure_region.current == {}
     - cm_rm_aws_region.previous.name == nm_rm_aws_region.previous.name == "us-west-1"

--- a/tests/integration/targets/mso_schema_site_vrf_region_cidr/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf_region_cidr/tasks/main.yml
@@ -148,7 +148,7 @@
     template: Template 1
     vrf: VRF2
     state: present
-  when: version.current.version[0] | int < 3
+  when: version.current.version is version('3', '<')
 
 - name: Ensure VRF1 exists at Site level for the physical site
   mso_schema_site_vrf:
@@ -460,7 +460,7 @@
     that:
     - nm_query_cidr_all_aws_2.msg == "Provided vrf 'VRF2' does not exist at site level."
     - nm_query_cidr_all_aws_3.msg == "Provided region 'us-west-1' does not exist. Existing regions{{':'}} "
-  when: version.current.version[0] | int < 3
+  when: version.current.version is version('3', '<')
 
 # REMOVE CIDR
 - name: Remove CIDR (check_mode)
@@ -588,7 +588,7 @@
   assert:
     that:
     - cm_query_non_vrf.msg == nm_query_non_vrf.msg == "Provided vrf 'non_existing_vrf' does not exist. Existing vrfs{{':'}} VRF1, VRF2"
-  when: version.current.version[0] | int < 3
+  when: version.current.version is version('3', '<')
 
 # USE A NON-EXISTING STATE
 - name: Non-existing state for site cidr (check_mode)

--- a/tests/integration/targets/mso_schema_site_vrf_region_cidr_subnet/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf_region_cidr_subnet/tasks/main.yml
@@ -115,7 +115,7 @@
     template: Template 1
     state: present
   loop: '{{ sites }}'
-  when: version.current.version[0] | int < 3
+  when: version.current.version is version('3', '<')
 
 - name: Ensure VRF1 exists
   mso_schema_template_vrf:

--- a/tests/integration/targets/mso_schema_site_vrf_region_hub_network/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf_region_hub_network/tasks/main.yml
@@ -29,4 +29,4 @@
 
 - name: Import hub_network tasks if MSO version is higher than 3.0
   import_tasks: hub_network.yml
-  when: version.current.version[0] | int >= 3
+  when: version.current.version is version('3', '>')

--- a/tests/integration/targets/mso_schema_template_anp_epg/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_anp_epg/tasks/main.yml
@@ -378,7 +378,6 @@
       scope: public
       shared: true
       no_default_gateway: false
-      querier: true
     - ip: 192.168.0.254/24
       description: "My description for a subnet"
       scope: private
@@ -426,25 +425,21 @@
     - nm_add_epg_3.current.subnets[0].noDefaultGateway == false
     - nm_add_epg_3.current.subnets[0].scope == "private"
     - nm_add_epg_3.current.subnets[0].shared == false
-    - nm_add_epg_3.current.subnets[0].querier == false
     - nm_add_epg_3.current.subnets[1].description == "1234567890"
     - nm_add_epg_3.current.subnets[1].ip == "10.0.1.254/24"
     - nm_add_epg_3.current.subnets[1].noDefaultGateway == false
     - nm_add_epg_3.current.subnets[1].scope == "private"
     - nm_add_epg_3.current.subnets[1].shared == false
-    - nm_add_epg_3.current.subnets[1].querier == false
     - nm_add_epg_3.current.subnets[2].description == "My description for a subnet"
     - nm_add_epg_3.current.subnets[2].ip == "172.16.0.1/24"
     - nm_add_epg_3.current.subnets[2].noDefaultGateway == false
     - nm_add_epg_3.current.subnets[2].scope == "public"
     - nm_add_epg_3.current.subnets[2].shared == true
-    - nm_add_epg_3.current.subnets[2].querier == true
     - nm_add_epg_3.current.subnets[3].description == "My description for a subnet"
     - nm_add_epg_3.current.subnets[3].ip == "192.168.0.254/24"
     - nm_add_epg_3.current.subnets[3].noDefaultGateway == true
     - nm_add_epg_3.current.subnets[3].scope == "private"
     - nm_add_epg_3.current.subnets[3].shared == false
-    - nm_add_epg_3.current.subnets[3].querier == false
 
 # CHANGE EPG
 - name: Change EPG (check_mode)
@@ -590,7 +585,6 @@
       scope: public
       shared: true
       no_default_gateway: false
-      querier: true
     - ip: 192.168.1.254/24
       description: "My description for a subnet"
       scope: private
@@ -615,13 +609,11 @@
       scope: private
       shared: false
       no_default_gateway: false
-      querier: false
     - ip: 192.168.1.254/24
       description: "My description for a subnet"
       scope: private
       shared: false
       no_default_gateway: false
-      querier: true
   register: nm_change_epg_1_subnets
 
 - name: Verify nm_change_epg_1_subnets
@@ -642,25 +634,21 @@
     - nm_change_epg_1_settings.current.subnets[0].noDefaultGateway == false
     - nm_change_epg_1_settings.current.subnets[0].scope == "private"
     - nm_change_epg_1_settings.current.subnets[0].shared == false
-    - nm_change_epg_1_settings.current.subnets[0].querier == false
     - nm_change_epg_1_settings.current.subnets[1].description == "1234567890"
     - nm_change_epg_1_settings.current.subnets[1].ip == "10.1.1.254/24"
     - nm_change_epg_1_settings.current.subnets[1].noDefaultGateway == false
     - nm_change_epg_1_settings.current.subnets[1].scope == "private"
     - nm_change_epg_1_settings.current.subnets[1].shared == false
-    - nm_change_epg_1_settings.current.subnets[1].querier == false
     - nm_change_epg_1_settings.current.subnets[2].description == "My description for a subnet"
     - nm_change_epg_1_settings.current.subnets[2].ip == "172.17.0.1/24"
     - nm_change_epg_1_settings.current.subnets[2].noDefaultGateway == false
     - nm_change_epg_1_settings.current.subnets[2].scope == "public"
     - nm_change_epg_1_settings.current.subnets[2].shared == true
-    - nm_change_epg_1_settings.current.subnets[2].querier == true
     - nm_change_epg_1_settings.current.subnets[3].description == "My description for a subnet"
     - nm_change_epg_1_settings.current.subnets[3].ip == "192.168.1.254/24"
     - nm_change_epg_1_settings.current.subnets[3].noDefaultGateway == true
     - nm_change_epg_1_settings.current.subnets[3].scope == "private"
     - nm_change_epg_1_settings.current.subnets[3].shared == false
-    - nm_change_epg_1_settings.current.subnets[3].querier == false
     - nm_change_epg_1_subnets is changed
     - nm_change_epg_1_subnets.current.subnets | length == 3
     - nm_change_epg_1_subnets.current.name == "ansible_test_1"
@@ -677,19 +665,16 @@
     - nm_change_epg_1_subnets.current.subnets[0].noDefaultGateway == false
     - nm_change_epg_1_subnets.current.subnets[0].scope == "private"
     - nm_change_epg_1_subnets.current.subnets[0].shared == false
-    - nm_change_epg_1_subnets.current.subnets[0].querier == false
     - nm_change_epg_1_subnets.current.subnets[1].description == "New description for a subnet"
     - nm_change_epg_1_subnets.current.subnets[1].ip == "172.17.0.1/24"
     - nm_change_epg_1_subnets.current.subnets[1].noDefaultGateway == false
     - nm_change_epg_1_subnets.current.subnets[1].scope == "private"
     - nm_change_epg_1_subnets.current.subnets[1].shared == false
-    - nm_change_epg_1_subnets.current.subnets[1].querier == false
     - nm_change_epg_1_subnets.current.subnets[2].description == "My description for a subnet"
     - nm_change_epg_1_subnets.current.subnets[2].ip == "192.168.1.254/24"
     - nm_change_epg_1_subnets.current.subnets[2].noDefaultGateway == false
     - nm_change_epg_1_subnets.current.subnets[2].scope == "private"
     - nm_change_epg_1_subnets.current.subnets[2].shared == false
-    - nm_change_epg_1_subnets.current.subnets[2].querier == true
 
 
 # # QUERY ALL EPGs
@@ -775,19 +760,16 @@
     - nm_query_epg_1.current.subnets[0].noDefaultGateway == false
     - nm_query_epg_1.current.subnets[0].scope == "private"
     - nm_query_epg_1.current.subnets[0].shared == false
-    - nm_query_epg_1.current.subnets[0].querier == false
     - nm_query_epg_1.current.subnets[1].description == "New description for a subnet"
     - nm_query_epg_1.current.subnets[1].ip == "172.17.0.1/24"
     - nm_query_epg_1.current.subnets[1].noDefaultGateway == false
     - nm_query_epg_1.current.subnets[1].scope == "private"
     - nm_query_epg_1.current.subnets[1].shared == false
-    - nm_query_epg_1.current.subnets[1].querier == false
     - nm_query_epg_1.current.subnets[2].description == "My description for a subnet"
     - nm_query_epg_1.current.subnets[2].ip == "192.168.1.254/24"
     - nm_query_epg_1.current.subnets[2].noDefaultGateway == false
     - nm_query_epg_1.current.subnets[2].scope == "private"
     - nm_query_epg_1.current.subnets[2].shared == false
-    - nm_query_epg_1.current.subnets[2].querier == true
     - nm_query_epg_3.current.name == "ansible_test_3"
     - nm_query_epg_4.current.name == "ansible_test_4"
     - nm_query_epg_3.current.vrfRef.templateName == nm_query_epg_4.current.vrfRef.templateName == "Template1"
@@ -804,25 +786,21 @@
     - nm_query_epg_3.current.subnets[0].noDefaultGateway == false
     - nm_query_epg_3.current.subnets[0].scope == "private"
     - nm_query_epg_3.current.subnets[0].shared == false
-    - nm_query_epg_3.current.subnets[0].querier == false
     - nm_query_epg_3.current.subnets[1].description == "1234567890"
     - nm_query_epg_3.current.subnets[1].ip == "10.0.1.254/24"
     - nm_query_epg_3.current.subnets[1].noDefaultGateway == false
     - nm_query_epg_3.current.subnets[1].scope == "private"
     - nm_query_epg_3.current.subnets[1].shared == false
-    - nm_query_epg_3.current.subnets[1].querier == false
     - nm_query_epg_3.current.subnets[2].description == "My description for a subnet"
     - nm_query_epg_3.current.subnets[2].ip == "172.16.0.1/24"
     - nm_query_epg_3.current.subnets[2].noDefaultGateway == false
     - nm_query_epg_3.current.subnets[2].scope == "public"
     - nm_query_epg_3.current.subnets[2].shared == true
-    - nm_query_epg_3.current.subnets[2].querier == true
     - nm_query_epg_3.current.subnets[3].description == "My description for a subnet"
     - nm_query_epg_3.current.subnets[3].ip == "192.168.0.254/24"
     - nm_query_epg_3.current.subnets[3].noDefaultGateway == true
     - nm_query_epg_3.current.subnets[3].scope == "private"
     - nm_query_epg_3.current.subnets[3].shared == false
-    - nm_query_epg_3.current.subnets[3].querier == false
     
 
 # REMOVE EPG

--- a/tests/integration/targets/mso_schema_template_bd/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_bd/tasks/main.yml
@@ -32,7 +32,7 @@
 - name: Set version vars
   set_fact:
     mso_l3mcast: false
-  when: version.current.version[:5] == '2.2.4'
+  when: version.current.version is version('2.2.4', '=')
 
 - name: Ensure site exist
   mso_site: &site_present
@@ -376,7 +376,7 @@
         version: 1
   register: nm_add_bd_5
 
-- name: Verify nm_add_bd_5 for a version that's not 3.1
+- name: Verify nm_add_bd_5 for a version that's before 3.1
   assert:
     that:
     - nm_add_bd_5 is changed
@@ -388,7 +388,7 @@
     - nm_add_bd_5.current.l2Stretch == true
     - nm_add_bd_5.current.l2UnknownUnicast == "flood"
     - nm_add_bd_5.current.l3MCast == false
-  when: version.current.version is version('3.1.1g', '!=')
+  when: version.current.version is version('3.1.1g', '<')
 
 - name: Verify nm_add_bd_5 for a version that's 3.1
   assert:
@@ -407,7 +407,7 @@
     - nm_add_bd_5.current.vmac == "00:00:5E:00:01:3C"
     - nm_add_bd_5.current.multiDstPktAct == "drop"
     - nm_add_bd_5.current.arpFlood == true
-  when: version.current.version is version('3.1.1g', '==')
+  when: version.current.version is version('3.1.1g', '>=')
 
 - name: Add bd 5 again (normal mode)
   mso_schema_template_bd:
@@ -437,17 +437,17 @@
         version: 1
   register: nm_add_again_bd_5
 
-- name: Verify nm_add_again_bd_5 for a version that's not 3.1
+- name: Verify nm_add_again_bd_5 for a version that's before 3.1
   assert:
     that:
     - nm_add_again_bd_5 is not changed
-  when: version.current.version is version('3.1.1g', '!=')
+  when: version.current.version is version('3.1.1g', '<')
 
 - name: Verify nm_add_again_bd_5 for a version that's 3.1
   assert:
     that:
     - nm_add_again_bd_5 is not changed
-  when: version.current.version is version('3.1.1g', '==')
+  when: version.current.version is version('3.1.1g', '>=')
 
 - name: Add bd 5 with different values for new options (normal mode)
   mso_schema_template_bd:
@@ -477,11 +477,11 @@
         version: 1
   register: nm_bd_5_options
 
-- name: Verify nm_bd_5_options for a version that's not 3.1
+- name: Verify nm_bd_5_options for a version that's before 3.1
   assert:
     that:
     - nm_bd_5_options is not changed
-  when: version.current.version is version('3.1.1g', '!=')
+  when: version.current.version is version('3.1.1g', '<')
 
 - name: Verify nm_bd_5_options for a version that's 3.1
   assert:
@@ -491,7 +491,7 @@
     - nm_bd_5_options.current.v6unkMcastAct == "opt-flood"
     - nm_bd_5_options.current.multiDstPktAct == "bd-flood"
     - nm_bd_5_options.current.vmac == "00:00:5E:00:02:3C"
-  when: version.current.version is version('3.1.1g', '==')
+  when: version.current.version is version('3.1.1g', '>=')
 
 - name: Change bd 5_1 (normal mode)
   mso_schema_template_bd:
@@ -521,18 +521,18 @@
         version: 1
   register: nm_change_bd_5_1
 
-- name: Verify nm_change_bd_5_1 for a version that's not 3.1
+- name: Verify nm_change_bd_5_1 for a version that's before 3.1
   assert:
     that:
     - nm_change_bd_5_1 is changed
-  when: version.current.version is version('3.1.1g', '!=')
+  when: version.current.version is version('3.1.1g', '<')
 
 - name: Verify nm_change_bd_5_1 for a version that's 3.1
   assert:
     that:
     - nm_change_bd_5_1 is changed
     - nm_change_bd_5_1.current.arpFlood == true
-  when: version.current.version is version('3.1.1g', '==')
+  when: version.current.version is version('3.1.1g', '>=')
 
 - name: Change bd 5_2 (normal mode)
   mso_schema_template_bd:
@@ -563,19 +563,19 @@
   ignore_errors: yes
   register: nm_change_bd_5_2
 
-- name: Verify nm_change_bd_5_2 for a version that's not 3.1
+- name: Verify nm_change_bd_5_2 for a version that's before 3.1
   assert:
     that:
     - nm_change_bd_5_2 is changed
     - nm_change_bd_5_2.current.l2UnknownUnicast == "flood"
-  when: version.current.version is version('3.1.1g', '!=')
+  when: version.current.version is version('3.1.1g', '<')
 
-- name: Verify nm_change_bd_5_2 for a version that's 3.1
+- name: Verify nm_change_bd_5_2 for a version that's after 3.1
   assert:
     that:
     - nm_change_bd_5_2 is changed
     - nm_change_bd_5_2.current.arpFlood == true
-  when: version.current.version is version('3.1.1g', '==')
+  when: version.current.version is version('3.1.1g', '>=')
 
 - name: Change bd 5_3 (normal mode)
   mso_schema_template_bd:
@@ -606,19 +606,20 @@
   ignore_errors: yes
   register: nm_change_bd_5_3
 
-- name: Verify nm_change_bd_5_3 for a version that's not 3.1
+- name: Verify nm_change_bd_5_3 for a version that's before 3.1
   assert:
     that:
     - nm_change_bd_5_3 is changed
     - nm_change_bd_5_3.msg is match ("MSO Error 143{{':'}} Invalid Field{{':'}} BD 'ansible_test_5' l2UnknownUnicast cannot be flood when intersiteBumTrafficAllow is off")
-  when: version.current.version is version('3.1.1g', '!=')
+  when: version.current.version is version('3.1.1g', '<')
 
-- name: Verify nm_change_bd_5_3 for a version that's 3.1
+- name: Verify nm_change_bd_5_3 for a version that's after 3.1
   assert:
     that:
     - nm_change_bd_5_3 is changed
     - nm_change_bd_5_3.msg is match ("MSO Error 400{{':'}} Bad Request{{':'}} Patch Failed, Received{{':'}} BD 'ansible_test_5' l2UnknownUnicast cannot be flood when intersiteBumTrafficAllow is off exception while trying to update schema")
-  when: version.current.version is version('3.1.1g', '==')
+  when: 
+  - version.current.version is version('3.1.1g', '>=')
 
 - name: Change bd 5 for query (normal mode)
   mso_schema_template_bd:
@@ -873,14 +874,14 @@
     that:
     - nm_change_bd_1_settings.current.l3MCast == false
     - nm_change_bd_1_subnets.current.l3MCast == false
-  when: version.current.version[:5] == '2.2.4'
+  when: version.current.version is version('2.2.4', '=')
 
 - name: Verify l3MCast nm_change_bd_1_subnets (version != 2.2.4)
   assert:
     that:
     - nm_change_bd_1_settings.current.l3MCast == true
     - nm_change_bd_1_subnets.current.l3MCast == true
-  when: version.current.version[:5] != '2.2.4'
+  when: version.current.version is version('2.2.4', '!=')
 
 # FIXME: Add missing DHCP Policy changes and checks (missing DHCP Policy module to make sure it is there.)
 
@@ -979,7 +980,7 @@
     - nm_query_bd_2.current.subnets[3].scope == "private"
     - nm_query_bd_2.current.subnets[3].shared == false
 
-- name: Verify nm_query_bd_5 for a version that's not 3.1
+- name: Verify nm_query_bd_5 for a version that's before 3.1
   assert:
     that:
     - nm_query_bd_5 is not changed
@@ -989,7 +990,7 @@
     - nm_query_bd_5.current.l2Stretch == true
     - nm_query_bd_5.current.l2UnknownUnicast == "flood"
     - nm_query_bd_5.current.l3MCast == false
-  when: version.current.version is version('3.1.1g', '!=')
+  when: version.current.version is version('3.1.1g', '<')
 
 - name: Verify nm_query_bd_5 for a version that's 3.1
   assert:
@@ -1006,7 +1007,7 @@
     - nm_query_bd_5.current.vmac == "00:00:5E:00:01:3C"
     - nm_query_bd_5.current.multiDstPktAct == "drop"
     - nm_query_bd_5.current.arpFlood == true
-  when: version.current.version is version('3.1.1g', '==')
+  when: version.current.version is version('3.1.1g', '>=')
 
 # REMOVE BD
 - name: Remove bd (check_mode)

--- a/tests/integration/targets/mso_schema_template_bd_subnet/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_bd_subnet/tasks/main.yml
@@ -32,7 +32,7 @@
 - name: Set version vars
   set_fact:
     mso_l3mcast: false
-  when: version.current.version[:5] == '2.2.4'
+  when: version.current.version is version('2.2.4', '=')
 
 - name: Ensure site exist
   mso_site: &site_present
@@ -228,7 +228,7 @@
     is_virtual_ip: true
   register: nm_add_subnet_2
 
-- name: Verify nm_bd_2 for a version that's not 3.1
+- name: Verify nm_bd_2 for a version that's < 3.1
   assert:
     that:
     - nm_add_subnet_2.current.ip == "10.1.1.1/24"
@@ -236,9 +236,9 @@
     - nm_add_subnet_2.current.scope == "public"
     - nm_add_subnet_2.current.shared == true
     - nm_add_subnet_2.current.querier == true
-  when: version.current.version is version('3.1.1g', '!=')
+  when: version.current.version is version('3.1.1g', '<')
 
-- name: Verify nm_bd_2 for a version that's 3.1
+- name: Verify nm_bd_2 for a version that's >= 3.1
   assert:
     that:
     - nm_add_subnet_2.current.ip == "10.1.1.1/24"
@@ -247,7 +247,7 @@
     - nm_add_subnet_2.current.shared == true
     - nm_add_subnet_2.current.querier == true
     - nm_add_subnet_2.current.virtual == true
-  when: version.current.version is version('3.1.1g', '==')
+  when: version.current.version is version('3.1.1g', '>=')
 
 # CHANGE Subnet
 - name: Change subnet 2 (normal mode)
@@ -265,7 +265,7 @@
     is_virtual_ip: false
   register: nm_change_subnet2
 
-- name: Verify nm_change_subnet2 for a version that's not 3.1
+- name: Verify nm_change_subnet2 for a version < 3.1
   assert:
     that:
     - nm_change_subnet2 is not changed
@@ -274,9 +274,9 @@
     - nm_change_subnet2.current.scope == "public"
     - nm_change_subnet2.current.shared == true
     - nm_change_subnet2.current.querier == true
-  when: version.current.version is version('3.1.1g', '!=')
+  when: version.current.version is version('3.1.1g', '<')
 
-- name: Verify nm_change_subnet2 for a version that's 3.1
+- name: Verify nm_change_subnet2 for a version >= 3.1
   assert:
     that:
     - nm_change_subnet2 is changed
@@ -286,7 +286,7 @@
     - nm_change_subnet2.current.shared == true
     - nm_change_subnet2.current.querier == true
     - nm_change_subnet2.current.virtual == false
-  when: version.current.version is version('3.1.1g', '==')
+  when: version.current.version is version('3.1.1g', '>=')
 
 - name: Change subnet2 again (normal mode)
   mso_schema_template_bd_subnet:
@@ -303,7 +303,7 @@
     is_virtual_ip: false
   register: nm_change_subnet2_again
 
-- name: Verify nm_change_subnet2_again for a version that's not 3.1
+- name: Verify nm_change_subnet2_again for a version that's < 3.1
   assert:
     that:
     - nm_change_subnet2_again is not changed
@@ -312,9 +312,9 @@
     - nm_change_subnet2_again.current.scope == "public"
     - nm_change_subnet2_again.current.shared == true
     - nm_change_subnet2_again.current.querier == true
-  when: version.current.version is version('3.1.1g', '!=')
+  when: version.current.version is version('3.1.1g', '<')
 
-- name: Verify cm_change_subnet2 for a version that's 3.1
+- name: Verify cm_change_subnet2 for a version that's >= 3.1
   assert:
     that:
     - nm_change_subnet2_again is not changed
@@ -324,7 +324,7 @@
     - nm_change_subnet2_again.current.shared == true
     - nm_change_subnet2_again.current.querier == true
     - nm_change_subnet2_again.current.virtual == false
-  when: version.current.version is version('3.1.1g', '==')
+  when: version.current.version is version('3.1.1g', '>=')
 
 # QUERY ALL Subnets
 - name: Query all subnet (check_mode)
@@ -359,7 +359,7 @@
     subnet: 10.1.1.1/24
   register: nm_query_subnet2
 
-- name: Verify nm_query_subnet2 for a version that's not 3.1
+- name: Verify nm_query_subnet2 for a version that's < 3.1
   assert:
     that:
     - nm_query_subnet2 is not changed
@@ -368,9 +368,9 @@
     - nm_query_subnet2.current.scope == "public"
     - nm_query_subnet2.current.shared == true
     - nm_query_subnet2.current.querier == true
-  when: version.current.version is version('3.1.1g', '!=')
+  when: version.current.version is version('3.1.1g', '<')
 
-- name: Verify nm_query_subnet2 for a version that's 3.1
+- name: Verify nm_query_subnet2 for a version that's >= 3.1
   assert:
     that:
     - nm_query_subnet2 is not changed
@@ -380,7 +380,7 @@
     - nm_query_subnet2.current.shared == true
     - nm_query_subnet2.current.querier == true
     - nm_query_subnet2.current.virtual == false
-  when: version.current.version is version('3.1.1g', '==')
+  when: version.current.version is version('3.1.1g', '>=')
 
 # REMOVE Subnet
 - name: Remove subnet

--- a/tests/integration/targets/mso_site/tasks/main.yml
+++ b/tests/integration/targets/mso_site/tasks/main.yml
@@ -10,15 +10,26 @@
 
 
 # CLEAN ENVIRONMENT
+- name: Set vars
+  set_fact: 
+    mso_info: &mso_info
+      host: '{{ mso_hostname }}'
+      username: '{{ mso_username }}'
+      password: '{{ mso_password }}'
+      validate_certs: '{{ mso_validate_certs | default(false) }}'
+      use_ssl: '{{ mso_use_ssl | default(true) }}'
+      use_proxy: '{{ mso_use_proxy | default(true) }}'
+      output_level: '{{ mso_output_level | default("info") }}'
+
+- name: Query MSO version
+  mso_version:
+    <<: *mso_info
+    state: query
+  register: version
+
 - name: Undeploy a schema 1 template 1
   mso_schema_template_deploy: &schema_undeploy
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
+    <<: *mso_info
     schema: ansible_test
     template: Template 1
     site: '{{ item }}'
@@ -53,13 +64,7 @@
 
 - name: Remove schemas
   mso_schema:
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
+    <<: *mso_info
     schema: '{{ item }}'
     state: absent
   loop:
@@ -68,13 +73,7 @@
 
 - name: Remove tenant ansible_test
   mso_tenant: &tenant_absent
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
+    <<: *mso_info
     tenant: ansible_test
     state: absent
 
@@ -86,13 +85,7 @@
 
 - name: Remove site
   mso_site: &site_absent
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
+    <<: *mso_info
     site: '{{ mso_site | default("ansible_test") }}'
     state: absent
 
@@ -106,13 +99,7 @@
 # ADD SITE
 - name: Add site (check_mode)
   mso_site: &site_present
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
+    <<: *mso_info
     site: '{{ mso_site | default("ansible_test") }}'
     apic_username: '{{ apic_username }}'
     apic_password: '{{ apic_password }}'
@@ -135,8 +122,21 @@
     that:
     - cm_add_site is changed
     - cm_add_site.previous == {}
+    
+
+- name: Verify cm_add_site (MSO)
+  assert:
+    that:
     - cm_add_site.current.id is not defined
     - cm_add_site.current.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '<')
+
+- name: Verify cm_add_site (ND)
+  assert:
+    that:
+    - cm_add_site.current.id == ""
+    - cm_add_site.current.common.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '>=')
 
 - name: Add site (normal mode)
   mso_site: *site_present
@@ -147,8 +147,19 @@
     that:
     - nm_add_site is changed
     - nm_add_site.previous == {}
+
+- name: Verify nm_add_site (MSO)
+  assert:
+    that:
     - nm_add_site.current.id is defined
     - nm_add_site.current.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '<')
+
+- name: Verify nm_add_site (ND)
+  assert:
+    that:
+    - nm_add_site.current.common.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '>=')
 
 - name: Add site again (check_mode)
   mso_site: *site_present
@@ -159,9 +170,21 @@
   assert:
     that:
     - cm_add_site_again is not changed
-    - cm_add_site_again.previous.name == mso_site|default("ansible_test")
     - cm_add_site_again.current.id == nm_add_site.current.id
+
+- name: Verify cm_add_site_again (MSO)
+  assert:
+    that:
+    - cm_add_site_again.previous.name == mso_site|default("ansible_test")
     - cm_add_site_again.current.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '<')
+
+- name: Verify cm_add_site_again (ND)
+  assert:
+    that:
+    - cm_add_site_again.previous.common.name == mso_site|default("ansible_test")
+    - cm_add_site_again.current.common.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '>=')
 
 - name: Add site again (normal mode)
   mso_site: *site_present
@@ -171,9 +194,21 @@
   assert:
     that:
     - nm_add_site_again is not changed
-    - nm_add_site_again.previous.name == mso_site|default("ansible_test")
     - nm_add_site_again.current.id == nm_add_site.current.id
+
+- name: Verify nm_add_site_again (MSO)
+  assert:
+    that:
+    - nm_add_site_again.previous.name == mso_site|default("ansible_test")
     - nm_add_site_again.current.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '<')
+
+- name: Verify nm_add_site_again (ND)
+  assert:
+    that:
+    - nm_add_site_again.previous.common.name == mso_site|default("ansible_test")
+    - nm_add_site_again.current.common.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '>=')
 
 
 # CHANGE SITE
@@ -194,13 +229,24 @@
 - name: Verify cm_change_site
   assert:
     that:
-    - cm_change_site is changed
     - cm_change_site.current.id == nm_add_site.current.id
-    - cm_change_site.current.name == '{{ mso_site | default("ansible_test") }}'
+
+- name: Verify cm_change_site (MSO)
+  assert:
+    that:
+    - cm_change_site is changed
     - cm_change_site.current.location.lat == 51.887318
     - cm_change_site.current.location.long == 5.447084
     - cm_change_site.current.labels[0] != nm_add_site.current.labels[0]
     - cm_change_site.current.labels[1] == nm_add_site.current.labels[1]
+    - cm_change_site.current.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '<')
+
+- name: Verify cm_change_site (ND)
+  assert:
+    that:
+    - cm_change_site.current.common.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '>=')
 
 - name: Change site (normal mode)
   mso_site:
@@ -219,13 +265,24 @@
 - name: Verify nm_change_site
   assert:
     that:
-    - nm_change_site is changed
     - nm_change_site.current.id == nm_add_site.current.id
-    - nm_change_site.current.name == '{{ mso_site | default("ansible_test") }}'
+
+- name: Verify nm_change_site (MSO)
+  assert:
+    that:
+    - nm_change_site is changed
     - nm_change_site.current.location.lat == 51.887318
     - nm_change_site.current.location.long == 5.447084
     - nm_change_site.current.labels[0] != nm_add_site.current.labels[0]
     - nm_change_site.current.labels[1] == nm_add_site.current.labels[1]
+    - nm_change_site.current.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '<')
+
+- name: Verify nm_change_site (ND)
+  assert:
+    that:
+    - nm_change_site.current.common.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '>=')
 
 - name: Change site again (check_mode)
   mso_site:
@@ -246,11 +303,22 @@
     that:
     - cm_change_site_again is not changed
     - cm_change_site_again.current.id == nm_add_site.current.id
-    - cm_change_site_again.current.name == '{{ mso_site | default("ansible_test") }}'
+
+- name: Verify cm_change_site_again (MSO)
+  assert:
+    that:
     - cm_change_site_again.current.location.lat == 51.887318
     - cm_change_site_again.current.location.long == 5.447084
     - cm_change_site_again.current.labels[0] == nm_change_site.current.labels[0]
     - cm_change_site_again.current.labels[1] == nm_change_site.current.labels[1]
+    - cm_change_site_again.current.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '<')
+
+- name: Verify cm_change_site_again (ND)
+  assert:
+    that:
+    - cm_change_site_again.current.common.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '>=')
 
 - name: Change site again (normal mode)
   mso_site:
@@ -271,22 +339,27 @@
     that:
     - nm_change_site_again is not changed
     - nm_change_site_again.current.id == nm_add_site.current.id
-    - nm_change_site_again.current.name == '{{ mso_site | default("ansible_test") }}'
+
+- name: Verify nm_change_site_again (MSO)
+  assert:
+    that:
     - nm_change_site_again.current.location.lat == 51.887318
     - nm_change_site_again.current.location.long == 5.447084
     - nm_change_site_again.current.labels[0] == nm_change_site.current.labels[0]
     - nm_change_site_again.current.labels[1] == nm_change_site.current.labels[1]
+    - nm_change_site_again.current.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '<')
+
+- name: Verify nm_change_site_again (ND)
+  assert:
+    that:
+    - nm_change_site_again.current.common.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '>=')
 
 # QUERY ALL SITES
 - name: Query all sites (check_mode)
   mso_site: &site_query
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
+    <<: *mso_info
     state: query
   check_mode: yes
   register: cm_query_all_sites
@@ -323,12 +396,23 @@
     that:
     - cm_query_site is not changed
     - cm_query_site.current.id == nm_add_site.current.id
-    - cm_query_site.current.name == '{{ mso_site | default("ansible_test") }}'
     - nm_query_site is not changed
     - nm_query_site.current.id == nm_add_site.current.id
-    - nm_query_site.current.name == '{{ mso_site | default("ansible_test") }}'
     - cm_query_site == nm_query_site
 
+- name: Verify query_site (MSO)
+  assert:
+    that:
+    - cm_query_site.current.name == mso_site|default("ansible_test")
+    - nm_query_site.current.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '<')
+
+- name: Verify query_site (ND)
+  assert:
+    that:
+    - cm_query_site.current.common.name == mso_site|default("ansible_test")
+    - nm_query_site.current.common.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '>=')
 
 # REMOVE SITE
 - name: Remove site (check_mode)
@@ -423,13 +507,7 @@
 # ADD SITE
 - name: Add site (normal_mode)
   mso_site:
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
+    <<: *mso_info
     site: '{{ mso_site | default("ansible_test") }}'
     apic_username: '{{ apic_username }}'
     apic_password: '{{ apic_password }}'
@@ -440,10 +518,21 @@
     state: present
   register: nm_add_site_no_location
 
-- name: Verify cm_add_site
+- name: Verify nm_add_site_no_location
   assert:
     that:
     - nm_add_site_no_location is changed
     - nm_add_site_no_location.previous == {}
     - nm_add_site_no_location.current.id is defined
+
+- name: Verify nm_add_site_no_location (MSO)
+  assert:
+    that:
     - nm_add_site_no_location.current.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '<')
+
+- name: Verify nm_add_site_no_location (ND)
+  assert:
+    that:
+    - nm_add_site_no_location.current.common.name == mso_site|default("ansible_test")
+  when: version.current.version is version('3.2', '>=')

--- a/tests/integration/targets/mso_tenant/tasks/main.yml
+++ b/tests/integration/targets/mso_tenant/tasks/main.yml
@@ -89,7 +89,7 @@
   - '{{ mso_schema | default("ansible_test") }}_2'
   - '{{ mso_schema | default("ansible_test") }}'
 
-- name: Remove tenant ansible_test
+- name: Remove tenants
   mso_tenant: &tenant_absent
     host: '{{ mso_hostname }}'
     username: '{{ mso_username }}'
@@ -98,21 +98,14 @@
     use_ssl: '{{ mso_use_ssl | default(true) }}'
     use_proxy: '{{ mso_use_proxy | default(true) }}'
     output_level: '{{ mso_output_level | default("info") }}'
-    tenant: ansible_test
+    tenant: '{{ item }}'
     state: absent
-
-- name: Remove tenant ansible_test2
-  mso_tenant:
-    <<: *tenant_absent
-    tenant: ansible_test2
-  register: cm_remove_tenant2
-
-- name: Remove tenant ansible_test3
-  mso_tenant:
-    <<: *tenant_absent
-    tenant: ansible_test3
-  register: cm_remove_tenant3
-
+  loop:
+  - ansible_test
+  - ansible_test2
+  - ansible_test3
+  - tenant_with_site
+  
 # ADD TENANT
 - name: Add tenant (check_mode)
   mso_tenant: &tenant_present
@@ -419,12 +412,14 @@
     - nm_query_tenant.current.id == nm_add_tenant.current.id
     - nm_query_tenant.current.name == 'ansible_test'
     - nm_query_tenant.current.description == 'Ansible test tenant 2'
-    - cm_query_tenant == nm_query_tenant
+    - cm_query_tenant.current == nm_query_tenant.current
 
 
 # REMOVE TENANT
 - name: Remove tenant (check_mode)
-  mso_tenant: *tenant_absent
+  mso_tenant: 
+    <<: *tenant_absent
+    tenant: ansible_test
   check_mode: yes
   register: cm_remove_tenant
 
@@ -435,7 +430,9 @@
     - cm_remove_tenant.current == {}
 
 - name: Remove tenant (normal mode)
-  mso_tenant: *tenant_absent
+  mso_tenant: 
+    <<: *tenant_absent
+    tenant: ansible_test
   register: nm_remove_tenant
 
 - name: Verify nm_remove_tenant
@@ -445,7 +442,9 @@
     - nm_remove_tenant.current == {}
 
 - name: Remove tenant again (check_mode)
-  mso_tenant: *tenant_absent
+  mso_tenant: 
+    <<: *tenant_absent
+    tenant: ansible_test
   check_mode: yes
   register: cm_remove_tenant_again
 
@@ -456,7 +455,9 @@
     - cm_remove_tenant_again.current == {}
 
 - name: Remove tenant again (normal mode)
-  mso_tenant: *tenant_absent
+  mso_tenant: 
+    <<: *tenant_absent
+    tenant: ansible_test
   register: nm_remove_tenant_again
 
 - name: Verify nm_remove_tenant_again
@@ -486,7 +487,7 @@
     that:
     - cm_query_non_tenant is not changed
     - nm_query_non_tenant is not changed
-    - cm_query_non_tenant == nm_query_non_tenant
+    - cm_query_non_tenant.current == nm_query_non_tenant.current
 
 - name: Add common tenant
   mso_tenant:

--- a/tests/integration/targets/mso_tenant/tasks/main.yml
+++ b/tests/integration/targets/mso_tenant/tasks/main.yml
@@ -20,10 +20,6 @@
       use_ssl: '{{ mso_use_ssl | default(true) }}'
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("info") }}'
-    apic_hostname_2: 173.36.219.123
-    apic_username_2: admin
-    apic_password_2: ins3965!
-    apic_site_id_2: 102
 
 - name: Ensure sites exists
   mso_site:
@@ -37,7 +33,7 @@
     state: present
   loop:
   - { site: '{{ mso_site | default("ansible_test") }}', username: '{{ apic_username }}', password: '{{ apic_password }}', id: '{{ apic_site_id | default(101) }}', urls: '{{ apic_hostname }}' }
-  - { site: '{{ mso_site | default("ansible_test") }}_2', username: '{{ apic_username_2 }}', password: '{{ apic_password_2 }}', id: '{{ apic_site_id_2 | default(101) }}', urls: '{{ apic_hostname_2 }}' }
+  - { site: 'aws_{{ mso_site | default("ansible_test") }}', username: '{{ aws_apic_username }}', password: '{{ aws_apic_password }}', id: '{{ aws_site_id | default(102) }}', urls: '{{ aws_apic_hostname }}' }
 
 - name: Undeploy a schema 1 template 1
   mso_schema_template_deploy: &schema_undeploy
@@ -49,7 +45,7 @@
   ignore_errors: yes
   loop:
   - '{{ mso_site | default("ansible_test") }}'
-  - '{{ mso_site | default("ansible_test") }}_2'
+  - 'aws_{{ mso_site | default("ansible_test") }}'
 
 - name: Undeploy a schema 1 template 2
   mso_schema_template_deploy:
@@ -60,7 +56,7 @@
   ignore_errors: yes
   loop:
   - '{{ mso_site | default("ansible_test") }}'
-  - '{{ mso_site | default("ansible_test") }}_2'
+  - 'aws_{{ mso_site | default("ansible_test") }}'
 
 - name: Undeploy a schema 2 template 3
   mso_schema_template_deploy:
@@ -72,7 +68,7 @@
   ignore_errors: yes
   loop:
   - '{{ mso_site | default("ansible_test") }}'
-  - '{{ mso_site | default("ansible_test") }}_2'
+  - 'aws_{{ mso_site | default("ansible_test") }}'
 
 - name: Remove schemas
   mso_schema:
@@ -494,7 +490,7 @@
     <<: *tenant_present
     tenant: common
     display_name: common
-    sites: [ansible_test, ansible_test_2]
+    sites: ['{{ mso_site | default("ansible_test") }}', 'aws_{{ mso_site | default("ansible_test") }}']
   register: nm_add_common_tenant
 
 - name: Verify nm_add_common_tenant
@@ -508,7 +504,7 @@
     <<: *tenant_present
     tenant: tenant_with_site
     display_name: tenant_with_site
-    sites: ansible_test
+    sites: '{{ mso_site | default("ansible_test") }}'
   register: nm_add_tenant_with_site
 
 - name: Verify nm_add_tenant_with_site

--- a/tests/integration/targets/mso_user/tasks/main.yml
+++ b/tests/integration/targets/mso_user/tasks/main.yml
@@ -375,12 +375,6 @@
 - name: Execute tasks only for MSO version < 3.2
   when: version.current.version is version('3.2', '<')
   block:
-  - name: Verify query_user and add_user have same id
-    assert:
-      that:
-      - cm_query_user.current.id == nm_add_user.current.id
-      - nm_query_user.current.id == nm_add_user.current.id
-
   - name: Query our read-only user
     mso_user:
       <<: *user_query

--- a/tests/integration/targets/mso_user/tasks/main.yml
+++ b/tests/integration/targets/mso_user/tasks/main.yml
@@ -8,345 +8,328 @@
     msg: 'Please define the following variables: mso_hostname, mso_username and mso_password.'
   when: mso_hostname is not defined or mso_username is not defined or mso_password is not defined
 
+- name: Set vars
+  set_fact:
+    mso_info: &mso_info
+      host: '{{ mso_hostname }}'
+      username: '{{ mso_username }}'
+      password: '{{ mso_password }}'
+      validate_certs: '{{ mso_validate_certs | default(false) }}'
+      use_ssl: '{{ mso_use_ssl | default(true) }}'
+      use_proxy: '{{ mso_use_proxy | default(true) }}'
+      output_level: '{{ mso_output_level | default("info") }}'
 
-# CLEAN ENVIRONMENT
-- name: Remove user ansible_test
-  mso_user: &user_absent
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
-    user: '{{ item }}'
-    state: absent
-  loop:
-  - ansible_test
-  - ansible_test2
-  - ansible_test_read
-  - ansible_test_read_2
+- name: Query MSO version
+  mso_version:
+    <<: *mso_info
+    state: query
+  register: version
 
-# ADD USER
-- name: Add user (check_mode)
-  mso_user: &user_present
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
-    user: ansible_test
-    user_password: 'S0m3!1n1t14l!p455w0rd'
-    # NOTE: First name, last name, phone and email are mandatory on creation
-    first_name: Ansible
-    last_name: Test
-    email: mso@cisco.com
-    phone: +32 478 436 299
-    account_status: active
-    roles:
-    - name: powerUser
-      access_type: write
-    domain: Local
-    state: present
-  check_mode: yes
-  register: cm_add_user
+- name: Execute tasks only for MSO version < 3.2
+  when: version.current.version is version('3.2', '<')
+  block:
+  # CLEAN ENVIRONMENT
+  - name: Remove user ansible_test
+    mso_user: &user_absent
+      <<: *mso_info
+      user: '{{ item }}'
+      state: absent
+    loop:
+    - ansible_test
+    - ansible_test2
+    - ansible_test_read
+    - ansible_test_read_2
 
-- name: Verify cm_add_user
-  assert:
-    that:
-    - cm_add_user is changed
-    - cm_add_user.previous == {}
-    - cm_add_user.current.id is not defined
-    - cm_add_user.current.username == 'ansible_test'
-    - cm_add_user.current.lastName == 'Test'
-    - cm_add_user.current.firstName == 'Ansible'
-    - cm_add_user.current.emailAddress == 'mso@cisco.com'
-    - cm_add_user.current.phoneNumber == '+32 478 436 299'
-    - cm_add_user.current.accountStatus == 'active'
-    - cm_add_user.current.roles[0].accessType == 'readWrite'
+  # ADD USER
+  - name: Add user (check_mode)
+    mso_user: &user_present
+      <<: *mso_info
+      user: ansible_test
+      user_password: 'S0m3!1n1t14l!p455w0rd'
+      # NOTE: First name, last name, phone and email are mandatory on creation
+      first_name: Ansible
+      last_name: Test
+      email: mso@cisco.com
+      phone: +32 478 436 299
+      account_status: active
+      roles:
+      - name: powerUser
+        access_type: write
+      domain: Local
+      state: present
+    check_mode: yes
+    register: cm_add_user
 
-- name: Add user (normal mode)
-  mso_user: *user_present
-  register: nm_add_user
+  - name: Verify cm_add_user
+    assert:
+      that:
+      - cm_add_user is changed
+      - cm_add_user.previous == {}
+      - cm_add_user.current.id is not defined
+      - cm_add_user.current.username == 'ansible_test'
+      - cm_add_user.current.lastName == 'Test'
+      - cm_add_user.current.firstName == 'Ansible'
+      - cm_add_user.current.emailAddress == 'mso@cisco.com'
+      - cm_add_user.current.phoneNumber == '+32 478 436 299'
+      - cm_add_user.current.accountStatus == 'active'
+      - cm_add_user.current.roles[0].accessType == 'readWrite'
 
-- name: Verify nm_add_user
-  assert:
-    that:
-    - nm_add_user is changed
-    - nm_add_user.previous == {}
-    - nm_add_user.current.id is defined
-    - nm_add_user.current.username == 'ansible_test'
-    - nm_add_user.current.lastName == 'Test'
-    - nm_add_user.current.firstName == 'Ansible'
-    - nm_add_user.current.emailAddress == 'mso@cisco.com'
-    - nm_add_user.current.phoneNumber == '+32 478 436 299'
-    - nm_add_user.current.accountStatus == 'active'
-    - nm_add_user.current.roles[0].accessType == 'readWrite'
+  - name: Add user (normal mode)
+    mso_user: *user_present
+    register: nm_add_user
 
-- name: Add user again (check_mode)
-  mso_user:
-    <<: *user_present
-    # NOTE: We need to modify the password for a new user
-    user_password: 'S0m3!n3w!p455w0rd'
-  check_mode: yes
-  register: cm_add_user_again
+  - name: Verify nm_add_user
+    assert:
+      that:
+      - nm_add_user is changed
+      - nm_add_user.previous == {}
+      - nm_add_user.current.id is defined
+      - nm_add_user.current.username == 'ansible_test'
+      - nm_add_user.current.lastName == 'Test'
+      - nm_add_user.current.firstName == 'Ansible'
+      - nm_add_user.current.emailAddress == 'mso@cisco.com'
+      - nm_add_user.current.phoneNumber == '+32 478 436 299'
+      - nm_add_user.current.accountStatus == 'active'
+      - nm_add_user.current.roles[0].accessType == 'readWrite'
 
-- name: Verify cm_add_user_again
-  assert:
-    that:
-    - cm_add_user_again is changed
-    - cm_add_user_again.previous.username == 'ansible_test'
-    - cm_add_user_again.current.id == nm_add_user.current.id
-    - cm_add_user_again.current.username == 'ansible_test'
+  - name: Add user again (check_mode)
+    mso_user:
+      <<: *user_present
+      # NOTE: We need to modify the password for a new user
+      user_password: 'S0m3!n3w!p455w0rd'
+    check_mode: yes
+    register: cm_add_user_again
 
-- name: Add user again (normal mode)
-  mso_user:
-    <<: *user_present
-    # NOTE: We need to modify the password for a new user
-    user_password: 'S0m3!n3w!p455w0rd'
-  register: nm_add_user_again
+  - name: Verify cm_add_user_again
+    assert:
+      that:
+      - cm_add_user_again is changed
+      - cm_add_user_again.previous.username == 'ansible_test'
+      - cm_add_user_again.current.id == nm_add_user.current.id
+      - cm_add_user_again.current.username == 'ansible_test'
 
-- name: Verify nm_add_user_again
-  assert:
-    that:
-    - nm_add_user_again is changed
-    - nm_add_user_again.previous.username == 'ansible_test'
-    - nm_add_user_again.current.id == nm_add_user.current.id
-    - nm_add_user_again.current.username == 'ansible_test'
+  - name: Add user again (normal mode)
+    mso_user:
+      <<: *user_present
+      # NOTE: We need to modify the password for a new user
+      user_password: 'S0m3!n3w!p455w0rd'
+    register: nm_add_user_again
 
-- name: Add user with read only role (check_mode)
-  mso_user: &user_present2
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
-    user: ansible_test_read
-    user_password: '#123455#123455Aa'
-    # NOTE: First name, last name, phone and email are mandatory on creation
-    first_name: Ansible2
-    last_name: Test2
-    email: mso3@cisco.com
-    phone: +32 478 436 299
-    account_status: active
-    roles:
-    - name: powerUser
-      access_type: read
-    domain: Local
-    state: present
-  check_mode: yes
-  register: cm_add_user2
+  - name: Verify nm_add_user_again
+    assert:
+      that:
+      - nm_add_user_again is changed
+      - nm_add_user_again.previous.username == 'ansible_test'
+      - nm_add_user_again.current.id == nm_add_user.current.id
+      - nm_add_user_again.current.username == 'ansible_test'
 
-- name: Verify cm_add_user2
-  assert:
-    that:
-    - cm_add_user2 is changed
-    - cm_add_user2.previous == {}
-    - cm_add_user2.current.id is not defined
-    - cm_add_user2.current.username == 'ansible_test_read'
-    - cm_add_user2.current.lastName == 'Test2'
-    - cm_add_user2.current.firstName == 'Ansible2'
-    - cm_add_user2.current.emailAddress == 'mso3@cisco.com'
-    - cm_add_user2.current.phoneNumber == '+32 478 436 299'
-    - cm_add_user2.current.accountStatus == 'active'
-    - cm_add_user2.current.roles[0].accessType == 'readOnly'
+  - name: Add user with read only role (check_mode)
+    mso_user: &user_present2
+      <<: *mso_info
+      user: ansible_test_read
+      user_password: '#123455#123455Aa'
+      # NOTE: First name, last name, phone and email are mandatory on creation
+      first_name: Ansible2
+      last_name: Test2
+      email: mso3@cisco.com
+      phone: +32 478 436 299
+      account_status: active
+      roles:
+      - name: powerUser
+        access_type: read
+      domain: Local
+      state: present
+    check_mode: yes
+    register: cm_add_user2
 
-- name: Add user with read only role (normal mode)
-  mso_user: *user_present2
-  register: nm_add_user2
+  - name: Verify cm_add_user2
+    assert:
+      that:
+      - cm_add_user2 is changed
+      - cm_add_user2.previous == {}
+      - cm_add_user2.current.id is not defined
+      - cm_add_user2.current.username == 'ansible_test_read'
+      - cm_add_user2.current.lastName == 'Test2'
+      - cm_add_user2.current.firstName == 'Ansible2'
+      - cm_add_user2.current.emailAddress == 'mso3@cisco.com'
+      - cm_add_user2.current.phoneNumber == '+32 478 436 299'
+      - cm_add_user2.current.accountStatus == 'active'
+      - cm_add_user2.current.roles[0].accessType == 'readOnly'
 
-- name: Verify nm_add_user2
-  assert:
-    that:
-    - nm_add_user2 is changed
-    - nm_add_user2.current.id is defined
-    - nm_add_user2.current.username == 'ansible_test_read'
-    - nm_add_user2.current.lastName == 'Test2'
-    - nm_add_user2.current.firstName == 'Ansible2'
-    - nm_add_user2.current.emailAddress == 'mso3@cisco.com'
-    - nm_add_user2.current.phoneNumber == '+32 478 436 299'
-    - nm_add_user2.current.accountStatus == 'active'
-    - nm_add_user2.current.roles[0].accessType == 'readOnly'
+  - name: Add user with read only role (normal mode)
+    mso_user: *user_present2
+    register: nm_add_user2
 
-- name: Add user with read only role again (check mode)
-  mso_user: 
-    <<: *user_present2
-    user_password: '#123455#123455Aa'
-  check_mode: yes  
-  register: cm_add_user2_again
+  - name: Verify nm_add_user2
+    assert:
+      that:
+      - nm_add_user2 is changed
+      - nm_add_user2.current.id is defined
+      - nm_add_user2.current.username == 'ansible_test_read'
+      - nm_add_user2.current.lastName == 'Test2'
+      - nm_add_user2.current.firstName == 'Ansible2'
+      - nm_add_user2.current.emailAddress == 'mso3@cisco.com'
+      - nm_add_user2.current.phoneNumber == '+32 478 436 299'
+      - nm_add_user2.current.accountStatus == 'active'
+      - nm_add_user2.current.roles[0].accessType == 'readOnly'
 
-- name: Add user with read only role again (normal mode)
-  mso_user: *user_present2
-  register: nm_add_user2
+  - name: Add user with read only role again (check mode)
+    mso_user:
+      <<: *user_present2
+      user_password: '#123455#123455Aa'
+    check_mode: yes
+    register: cm_add_user2_again
 
-- name: Add user3 with read only role and no password (check_mode)
-  mso_user:  &user_present3
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
-    user: ansible_test_read_2
-    # NOTE: First name, last name, phone and email are mandatory on creation
-    first_name: Ansible3
-    #user_password: '#123455#123455Aa'
-    last_name: Test3
-    email: mso4@cisco.com
-    phone: +32 478 436 299
-    account_status: active
-    roles:
-    - name: powerUser
-      access_type: read
-    domain: Local
-    state: present
-  ignore_errors: yes
-  register: nm_add_user3
+  - name: Add user with read only role again (normal mode)
+    mso_user: *user_present2
+    register: nm_add_user2
 
-- name: Verify nm_add_user2
-  assert:
-    that:
-    - nm_add_user3.msg ==  "The user ansible_test_read_2 does not exist. The 'user_password' attribute is required to create a new user."
+  - name: Add user3 with read only role and no password (check_mode)
+    mso_user:  &user_present3
+      <<: *mso_info
+      user: ansible_test_read_2
+      # NOTE: First name, last name, phone and email are mandatory on creation
+      first_name: Ansible3
+      #user_password: '#123455#123455Aa'
+      last_name: Test3
+      email: mso4@cisco.com
+      phone: +32 478 436 299
+      account_status: active
+      roles:
+      - name: powerUser
+        access_type: read
+      domain: Local
+      state: present
+    ignore_errors: yes
+    register: nm_add_user3
 
-- name: Add user3 with read only role and with password (normal mode)
-  mso_user: 
-    <<: *user_present3
-    user_password: '#123455#123455Aa'
-  register: nm_add_user3_again
+  - name: Verify nm_add_user2
+    assert:
+      that:
+      - nm_add_user3.msg ==  "The user ansible_test_read_2 does not exist. The 'user_password' attribute is required to create a new user."
 
-- name: Verify nm_add_user3_again
-  assert:
-    that:
-    - nm_add_user3_again is changed
-    - nm_add_user3_again.current.id is defined
-    - nm_add_user3_again.current.username == 'ansible_test_read_2'
-    - nm_add_user3_again.current.lastName == 'Test3'
-    - nm_add_user3_again.current.firstName == 'Ansible3'
-    - nm_add_user3_again.current.emailAddress == 'mso4@cisco.com'
-    - nm_add_user3_again.current.phoneNumber == '+32 478 436 299'
-    - nm_add_user3_again.current.accountStatus == 'active'
-    - nm_add_user3_again.current.roles[0].accessType == 'readOnly'
+  - name: Add user3 with read only role and with password (normal mode)
+    mso_user:
+      <<: *user_present3
+      user_password: '#123455#123455Aa'
+    register: nm_add_user3_again
 
-# CHANGE USER
-- name: Change user (check_mode)
-  mso_user: &user_change
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
-    user: ansible_test
-    roles:
-    - name: powerUser
-      access_type: write
-    domain: Local
-    state: present
-    # FIXME: Add support for name change
-    email: mso2@cisco.com
-    phone: +32 478 436 300
-  check_mode: yes
-  register: cm_change_user
+  - name: Verify nm_add_user3_again
+    assert:
+      that:
+      - nm_add_user3_again is changed
+      - nm_add_user3_again.current.id is defined
+      - nm_add_user3_again.current.username == 'ansible_test_read_2'
+      - nm_add_user3_again.current.lastName == 'Test3'
+      - nm_add_user3_again.current.firstName == 'Ansible3'
+      - nm_add_user3_again.current.emailAddress == 'mso4@cisco.com'
+      - nm_add_user3_again.current.phoneNumber == '+32 478 436 299'
+      - nm_add_user3_again.current.accountStatus == 'active'
+      - nm_add_user3_again.current.roles[0].accessType == 'readOnly'
 
-- name: Verify cm_change_user
-  assert:
-    that:
-    - cm_change_user is changed
-    - cm_change_user.current.id == nm_add_user.current.id
-    - cm_change_user.current.username == 'ansible_test'
-    - cm_change_user.current.emailAddress == 'mso2@cisco.com'
-    - cm_change_user.current.phoneNumber == '+32 478 436 300'
+  # CHANGE USER
+  - name: Change user (check_mode)
+    mso_user: &user_change
+      <<: *mso_info
+      user: ansible_test
+      roles:
+      - name: powerUser
+        access_type: write
+      domain: Local
+      state: present
+      # FIXME: Add support for name change
+      email: mso2@cisco.com
+      phone: +32 478 436 300
+    check_mode: yes
+    register: cm_change_user
 
-- name: Change user (normal mode)
-  mso_user:
-    <<: *user_change
-    output_level: debug
-  register: nm_change_user
+  - name: Verify cm_change_user
+    assert:
+      that:
+      - cm_change_user is changed
+      - cm_change_user.current.id == nm_add_user.current.id
+      - cm_change_user.current.username == 'ansible_test'
+      - cm_change_user.current.emailAddress == 'mso2@cisco.com'
+      - cm_change_user.current.phoneNumber == '+32 478 436 300'
 
-- name: Verify nm_change_user
-  assert:
-    that:
-    - nm_change_user is changed
-    - nm_change_user.current.id == nm_add_user.current.id
-    - nm_change_user.current.username == 'ansible_test'
-    - nm_change_user.current.emailAddress == 'mso2@cisco.com'
-    - nm_change_user.current.phoneNumber == '+32 478 436 300'
+  - name: Change user (normal mode)
+    mso_user:
+      <<: *user_change
+      output_level: debug
+    register: nm_change_user
 
-- name: Change user again (check_mode)
-  mso_user:
-    <<: *user_change
-  check_mode: yes
-  register: cm_change_user_again
+  - name: Verify nm_change_user
+    assert:
+      that:
+      - nm_change_user is changed
+      - nm_change_user.current.id == nm_add_user.current.id
+      - nm_change_user.current.username == 'ansible_test'
+      - nm_change_user.current.emailAddress == 'mso2@cisco.com'
+      - nm_change_user.current.phoneNumber == '+32 478 436 300'
 
-- name: Verify cm_change_user_again
-  assert:
-    that:
-    - cm_change_user_again is not changed
-    - cm_change_user_again.current.id == nm_add_user.current.id
-    - cm_change_user_again.current.username == 'ansible_test'
-    - cm_change_user_again.current.emailAddress == 'mso2@cisco.com'
-    - cm_change_user_again.current.phoneNumber == '+32 478 436 300'
+  - name: Change user again (check_mode)
+    mso_user:
+      <<: *user_change
+    check_mode: yes
+    register: cm_change_user_again
 
-- name: Change user again (normal mode)
-  mso_user:
-    <<: *user_change
-  register: nm_change_user_again
+  - name: Verify cm_change_user_again
+    assert:
+      that:
+      - cm_change_user_again is not changed
+      - cm_change_user_again.current.id == nm_add_user.current.id
+      - cm_change_user_again.current.username == 'ansible_test'
+      - cm_change_user_again.current.emailAddress == 'mso2@cisco.com'
+      - cm_change_user_again.current.phoneNumber == '+32 478 436 300'
 
-- name: Verify nm_change_user_again
-  assert:
-    that:
-    - nm_change_user_again is not changed
-    - nm_change_user_again.current.id == nm_add_user.current.id
-    - nm_change_user_again.current.username == 'ansible_test'
-    - nm_change_user_again.current.emailAddress == 'mso2@cisco.com'
-    - nm_change_user_again.current.phoneNumber == '+32 478 436 300'
+  - name: Change user again (normal mode)
+    mso_user:
+      <<: *user_change
+    register: nm_change_user_again
 
-- name: Add second user
-  mso_user:
-    <<: *user_change
-    user: ansible_test2
-    user_password: 'S0m3!1n1t14l!p455w0rd'
-    first_name: Ansible
-    last_name: Test
-    roles:
-    - powerUser
-    state: present
-  register: nm_add_user_2
+  - name: Verify nm_change_user_again
+    assert:
+      that:
+      - nm_change_user_again is not changed
+      - nm_change_user_again.current.id == nm_add_user.current.id
+      - nm_change_user_again.current.username == 'ansible_test'
+      - nm_change_user_again.current.emailAddress == 'mso2@cisco.com'
+      - nm_change_user_again.current.phoneNumber == '+32 478 436 300'
 
-- name: Change user 2 again (normal mode)
-  mso_user:
-    <<: *user_change
-    user: ansible_test2
-    user_password: null
-    first_name: Ansible
-    last_name: Test
-  register: nm_change_user_2_again
+  - name: Add second user
+    mso_user:
+      <<: *user_change
+      user: ansible_test2
+      user_password: 'S0m3!1n1t14l!p455w0rd'
+      first_name: Ansible
+      last_name: Test
+      roles:
+      - powerUser
+      state: present
+    register: nm_add_user_2
 
-- name: Verify nm_change_user_2_again
-  assert:
-    that:
-    - nm_change_user_2_again is not changed
-    - nm_change_user_2_again.current.id == nm_add_user_2.current.id
-    - nm_change_user_2_again.current.username == 'ansible_test2'
+  - name: Change user 2 again (normal mode)
+    mso_user:
+      <<: *user_change
+      user: ansible_test2
+      user_password: null
+      first_name: Ansible
+      last_name: Test
+    register: nm_change_user_2_again
 
-# TODO: Add query with user ansible_test2 to try if user can login.
+  - name: Verify nm_change_user_2_again
+    assert:
+      that:
+      - nm_change_user_2_again is not changed
+      - nm_change_user_2_again.current.id == nm_add_user_2.current.id
+      - nm_change_user_2_again.current.username == 'ansible_test2'
+
+  # TODO: Add query with user ansible_test2 to try if user can login.
 
 # QUERY ALL USERS
 - name: Query all users (check_mode)
   mso_user: &user_query
-    host: '{{ mso_hostname }}'
-    username: '{{ mso_username }}'
-    password: '{{ mso_password }}'
-    validate_certs: '{{ mso_validate_certs | default(false) }}'
-    use_ssl: '{{ mso_use_ssl | default(true) }}'
-    use_proxy: '{{ mso_use_proxy | default(true) }}'
-    output_level: '{{ mso_output_level | default("info") }}'
+    <<: *mso_info
     state: query
   check_mode: yes
   register: cm_query_all_users
@@ -368,93 +351,102 @@
 - name: Query our user
   mso_user:
     <<: *user_query
-    user: ansible_test
+    user: '{{ mso_username }}'
   check_mode: yes
   register: cm_query_user
 
 - name: Query our user
   mso_user:
     <<: *user_query
-    user: ansible_test
+    user: '{{ mso_username }}'
   register: nm_query_user
 
 - name: Verify query_user
   assert:
     that:
     - cm_query_user is not changed
-    - cm_query_user.current.id == nm_add_user.current.id
-    - cm_query_user.current.username == 'ansible_test'
+    - cm_query_user.current.id is defined
+    - cm_query_user.current.username == '{{ mso_username }}'
     - nm_query_user is not changed
-    - nm_query_user.current.id == nm_add_user.current.id
-    - nm_query_user.current.username == 'ansible_test'
+    - nm_query_user.current.id is defined
+    - nm_query_user.current.username == '{{ mso_username }}'
     - cm_query_user == nm_query_user
 
-- name: Query our read-only user
-  mso_user:
-    <<: *user_query
-    user: ansible_test_read
-  register: nm_query_user2
+- name: Execute tasks only for MSO version < 3.2
+  when: version.current.version is version('3.2', '<')
+  block:
+  - name: Verify query_user and add_user have same id
+    assert:
+      that:
+      - cm_query_user.current.id == nm_add_user.current.id
+      - nm_query_user.current.id == nm_add_user.current.id
 
-- name: Verify query_user2
-  assert:
-    that:
-    - nm_query_user2 is not changed
-    - nm_query_user2.current.roles[0].accessType == 'readOnly'
+  - name: Query our read-only user
+    mso_user:
+      <<: *user_query
+      user: ansible_test_read
+    register: nm_query_user2
 
-# REMOVE USER
-- name: Remove user (check_mode)
-  mso_user: 
-    <<: *user_absent
-    user: ansible_test
-    state: absent
-  check_mode: yes
-  register: cm_remove_user
+  - name: Verify query_user2
+    assert:
+      that:
+      - nm_query_user2 is not changed
+      - nm_query_user2.current.roles[0].accessType == 'readOnly'
 
-- name: Verify cm_remove_user
-  assert:
-    that:
-    - cm_remove_user is changed
-    - cm_remove_user.current == {}
+  # REMOVE USER
+  - name: Remove user (check_mode)
+    mso_user:
+      <<: *user_absent
+      user: ansible_test
+      state: absent
+    check_mode: yes
+    register: cm_remove_user
 
-- name: Remove user (normal mode)
-  mso_user:
-    <<: *user_absent
-    user: ansible_test
-    state: absent
-  register: nm_remove_user
+  - name: Verify cm_remove_user
+    assert:
+      that:
+      - cm_remove_user is changed
+      - cm_remove_user.current == {}
 
-- name: Verify nm_remove_user
-  assert:
-    that:
-    - nm_remove_user is changed
-    - nm_remove_user.current == {}
+  - name: Remove user (normal mode)
+    mso_user:
+      <<: *user_absent
+      user: ansible_test
+      state: absent
+    register: nm_remove_user
 
-- name: Remove user again (check_mode)
-  mso_user:
-    <<: *user_absent
-    user: ansible_test
-    state: absent
-  check_mode: yes
-  register: cm_remove_user_again
+  - name: Verify nm_remove_user
+    assert:
+      that:
+      - nm_remove_user is changed
+      - nm_remove_user.current == {}
 
-- name: Verify cm_remove_user_again
-  assert:
-    that:
-    - cm_remove_user_again is not changed
-    - cm_remove_user_again.current == {}
+  - name: Remove user again (check_mode)
+    mso_user:
+      <<: *user_absent
+      user: ansible_test
+      state: absent
+    check_mode: yes
+    register: cm_remove_user_again
 
-- name: Remove user again (normal mode)
-  mso_user:
-    <<: *user_absent
-    user: ansible_test
-    state: absent
-  register: nm_remove_user_again
+  - name: Verify cm_remove_user_again
+    assert:
+      that:
+      - cm_remove_user_again is not changed
+      - cm_remove_user_again.current == {}
 
-- name: Verify nm_remove_user_again
-  assert:
-    that:
-    - nm_remove_user_again is not changed
-    - nm_remove_user_again.current == {}
+  - name: Remove user again (normal mode)
+    mso_user:
+      <<: *user_absent
+      user: ansible_test
+      state: absent
+    register: nm_remove_user_again
+
+  - name: Verify nm_remove_user_again
+    assert:
+      that:
+      - nm_remove_user_again is not changed
+      - nm_remove_user_again.current == {}
 
 # QUERY NON-EXISTING USER
 - name: Query non-existing user (check_mode)
@@ -478,45 +470,48 @@
     - nm_query_non_user is not changed
     - cm_query_non_user == nm_query_non_user
 
-- name: inactive user (check_mode)
-  mso_user:
-    <<: *user_present
-    account_status: inactive
-  check_mode: yes
-  register: cm_inactive_user
+- name: Execute tasks only for MSO version < 3.2
+  when: version.current.version is version('3.2', '<')
+  block:
+  - name: inactive user (check_mode)
+    mso_user:
+      <<: *user_present
+      account_status: inactive
+    check_mode: yes
+    register: cm_inactive_user
 
-- name: inactive user (normal_mode)
-  mso_user: 
-    <<: *user_present
-    account_status: inactive
-  register: nm_inactive_user
+  - name: inactive user (normal_mode)
+    mso_user:
+      <<: *user_present
+      account_status: inactive
+    register: nm_inactive_user
 
-- name: Verify cm_inactive_user and nm_inactive_user
-  assert:
-    that:
-    - cm_inactive_user is changed
-    - nm_inactive_user is changed
-    - cm_inactive_user.current.accountStatus == "inactive"
-    - nm_inactive_user.current.accountStatus == "inactive"
+  - name: Verify cm_inactive_user and nm_inactive_user
+    assert:
+      that:
+      - cm_inactive_user is changed
+      - nm_inactive_user is changed
+      - cm_inactive_user.current.accountStatus == "inactive"
+      - nm_inactive_user.current.accountStatus == "inactive"
 
 
-- name: active user (check_mode)
-  mso_user:
-    <<: *user_present
-    account_status: active
-  check_mode: yes
-  register: cm_active_user
+  - name: active user (check_mode)
+    mso_user:
+      <<: *user_present
+      account_status: active
+    check_mode: yes
+    register: cm_active_user
 
-- name: active user (normal_mode)
-  mso_user: 
-    <<: *user_present
-    account_status: active
-  register: nm_active_user
+  - name: active user (normal_mode)
+    mso_user:
+      <<: *user_present
+      account_status: active
+    register: nm_active_user
 
-- name: Verify cm_active_user and nm_active_user
-  assert:
-    that:
-    - cm_active_user is changed
-    - nm_active_user is changed
-    - cm_active_user.previous.accountStatus == nm_active_user.previous.accountStatus == "inactive"
-    - cm_active_user.current.accountStatus == nm_active_user.current.accountStatus == "active"
+  - name: Verify cm_active_user and nm_active_user
+    assert:
+      that:
+      - cm_active_user is changed
+      - nm_active_user is changed
+      - cm_active_user.previous.accountStatus == nm_active_user.previous.accountStatus == "inactive"
+      - cm_active_user.current.accountStatus == nm_active_user.current.accountStatus == "active"


### PR DESCRIPTION
This PR brings a new MSO HTTPAPI connection plugin which also provide the ability to swap the MSO connection plugin with the new ND connection plugin for MSO version >= 3.2.

Various fixes to code and test cases to accommodate those changes.
Also fixed a few documentation issues and fixed fail_json usage across module_utils/mso.py