### PR TITLE
Update mso_schema_site_anp_epg_domain for supporting ndo 4.2 on vmm d…

### DIFF
--- a/plugins/modules/mso_schema_site_anp_epg_domain.py
+++ b/plugins/modules/mso_schema_site_anp_epg_domain.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2019, Nirav Katarmal (@nkatarmal-crest) <nirav.katarmal@crestdatasys.com>
+# Copyright: (c) 2023, Mabille Florent (@fmabille09) <florent.mabille@smals.be>
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -279,7 +280,7 @@ def main():
         supports_check_mode=True,
         required_if=[
             ["state", "absent", ["domain_association_type", "domain_profile", "deployment_immediacy", "resolution_immediacy"]],
-            ["state", "present", ["domain_association_type", "domain_profile", "deployment_immediacy", "resolution_immediacy", "binding_type", "netflow_pref", "allow_promiscuous", "forged_transmits", "mac_changes"]],
+            ["state", "present", ["domain_association_type", "domain_profile", "deployment_immediacy", "resolution_immediacy"]],
         ],
     )
 
@@ -458,7 +459,6 @@ def main():
         macChanges=mac_changes
     )
 
-
     if domain_association_type == "vmmDomain":
         vmmDomainProperties = {}
         if micro_seg_vlan_type and micro_seg_vlan:
@@ -479,7 +479,6 @@ def main():
 
         if vlan_encap_mode:
             vmmDomainProperties["vlanEncapMode"] = vlan_encap_mode
-        
 
         if binding_type == "dynamic" and not port_allocation:
             vmmDomainProperties["numPorts"] = num_ports

--- a/plugins/modules/mso_schema_site_anp_epg_domain.py
+++ b/plugins/modules/mso_schema_site_anp_epg_domain.py
@@ -117,34 +117,41 @@ options:
   binding_type:
     description:
     - Which binding_type to use with this domain association. This attribute can only be used with vmmDomain domain association.
+    - Defaults to C(none) when unset during creation.
     type: str
     choices: [ static, dynamic, none, ephemeral ]
   num_ports:
     description:
     - Number of ports for the binding type. This attribute can only be used with vmmDomain domain association.
+    - Must be defined if binding is set to static or dynamic.
     type: str
   port_allocation:
     description:
     - Port allocation for the binding type. This attribute can only be used with vmmDomain domain association and binding type in static.
+    - Must be defined if binding is set to static.
     type: str
   netflow_pref:
     description:
     - Which netflow_pref to use with this domain association. This attribute can only be used with vmmDomain domain association.
+    - Defaults to C(disabled) when unset during creation.
     type: str
     choices: [ enabled, disabled ]
   allow_promiscuous:
     description:
     - Which allow_promiscuous to use with this domain association. This attribute can only be used with vmmDomain domain association.
+    - Defaults to C(reject) when unset during creation.
     type: str
     choices: [ accept, reject ]
   forged_transmits:
     description:
     - Which forged_transmits to use with this domain association. This attribute can only be used with vmmDomain domain association.
+    - Defaults to C(reject) when unset during creation.
     type: str
     choices: [ accept, reject ]
   mac_changes:
     description:
     - Which mac_changes to use with this domain association. This attribute can only be used with vmmDomain domain association.
+    - Defaults to C(reject) when unset during creation.
     type: str
     choices: [ accept, reject ]
   custom_epg_name:


### PR DESCRIPTION
…omain

New supported parameters for vmm domain association:
- delimeter
- custom_epg_name
- mac_changes
- forget_transmits
- netflow_pref
- num_port
- port_allocation
- binding_type
- allow_promiscuous

Some of them are mandatory now