### PR TITLE
fixed typo

### DIFF
--- a/plugins/modules/mso_schema_template_deploy.py
+++ b/plugins/modules/mso_schema_template_deploy.py
@@ -72,7 +72,7 @@ EXAMPLES = r"""
     state: undeploy
 
 - name: Get deployment status
-  cisco.mso.mso_schema:
+  cisco.mso.mso_schema_template_deploy:
     host: mso_host
     username: admin
     password: SomeSecretPassword


### PR DESCRIPTION
Corrected a typo in the 'Examples' section of the `mso_schema_template_deploy` module documentation.