### PR TITLE
[EPG Static Port] Make VLAN parameter optional when the state is absent (DCNE-300)

### DIFF
--- a/plugins/modules/mso_schema_site_anp_epg_staticport.py
+++ b/plugins/modules/mso_schema_site_anp_epg_staticport.py
@@ -441,9 +441,14 @@ def main():
     state = module.params.get("state")
 
     if not static_ports and state in ["present", "absent"]:
-        key_list = ["pod", "leaf", "path", "vlan"]
+        if state == "absent":
+          # The state absent requires at least the pod, leaf and path to be provided
+          key_list = ["pod", "leaf", "path"]
+        else:
+          # The state present requires all the key_list to be provided
+          key_list = ["pod", "leaf", "path", "vlan"]
         required_missing = [key for key in key_list if module.params.get(key)]
-        if len(required_missing) != 4 and not (len(required_missing) == 0 and state == "absent" and force_replace):
+        if len(required_missing) != len(key_list) and not (len(required_missing) == 0 and state == "absent" and force_replace):
             module.fail_json(
                 msg="state is present or absent but all of the following are missing: {0}.".format(
                     ", ".join([key for key in key_list if not module.params.get(key)]),
@@ -497,7 +502,7 @@ def main():
         set_existing_static_ports(mso, mso_schema, full_paths)
         for static_port in static_ports:
             overwrite_static_path_unprovided_attributes(
-                mso, static_port, path_type, pod, leaf, fex, path, vlan, primary_micro_segment_vlan, deployment_immediacy, mode
+                state, mso, static_port, path_type, pod, leaf, fex, path, vlan, primary_micro_segment_vlan, deployment_immediacy, mode
             )
             full_path = get_full_static_path(
                 static_port.get("type"), static_port.get("pod"), static_port.get("leaf"), static_port.get("fex"), static_port.get("path")
@@ -507,7 +512,7 @@ def main():
                 found_static_ports.append(mso_schema.schema_objects["site_anp_epg_static_port"].details)
                 found_full_paths.append(full_path)
 
-    elif path_type and pod and leaf and path and vlan:
+    elif (path_type and pod and leaf and path) and (vlan or (state == "absent")):
         full_path = get_full_static_path(path_type, pod, leaf, fex, path)
         mso_schema.set_site_anp_epg_static_port(full_path, False)
         if mso_schema.schema_objects.get("site_anp_epg_static_port") is not None:
@@ -646,7 +651,7 @@ def get_full_static_path(path_type, pod, leaf, fex, path):
         return "topology/{0}/paths-{1}/pathep-[{2}]".format(pod, leaf, path)
 
 
-def overwrite_static_path_unprovided_attributes(mso, static_path, path_type, pod, leaf, fex, path, vlan, micro_vlan, deployment_immediacy, mode):
+def overwrite_static_path_unprovided_attributes(state, mso, static_path, path_type, pod, leaf, fex, path, vlan, micro_vlan, deployment_immediacy, mode):
     required_overwrites = []
     if not static_path.get("type"):
         static_path["type"] = path_type
@@ -666,7 +671,8 @@ def overwrite_static_path_unprovided_attributes(mso, static_path, path_type, pod
             required_overwrites.append("path")
     if not static_path.get("vlan"):
         static_path["vlan"] = vlan
-        if not vlan:
+        if not vlan and state != "absent":
+            # The vlan is not required when the state is absent
             required_overwrites.append("vlan")
     if not static_path.get("primary_micro_segment_vlan"):
         static_path["primary_micro_segment_vlan"] = micro_vlan

--- a/plugins/modules/mso_schema_site_anp_epg_staticport.py
+++ b/plugins/modules/mso_schema_site_anp_epg_staticport.py
@@ -442,11 +442,11 @@ def main():
 
     if not static_ports and state in ["present", "absent"]:
         if state == "absent":
-          # The state absent requires at least the pod, leaf and path to be provided
-          key_list = ["pod", "leaf", "path"]
+            # The state absent requires at least the pod, leaf and path to be provided
+            key_list = ["pod", "leaf", "path"]
         else:
-          # The state present requires all the key_list to be provided
-          key_list = ["pod", "leaf", "path", "vlan"]
+            # The state present requires all the key_list to be provided
+            key_list = ["pod", "leaf", "path", "vlan"]
         required_missing = [key for key in key_list if module.params.get(key)]
         if len(required_missing) != len(key_list) and not (len(required_missing) == 0 and state == "absent" and force_replace):
             module.fail_json(

--- a/plugins/modules/mso_schema_site_anp_epg_staticport.py
+++ b/plugins/modules/mso_schema_site_anp_epg_staticport.py
@@ -3,6 +3,7 @@
 
 # Copyright: (c) 2019, Dag Wieers (@dagwieers) <dag@wieers.com>
 # Copyright: (c) 2024, Akini Ross (@akinross) <akinross@cisco.com>
+# Copyright: (c) 2024, Noppanut Ploywong (@noppanut15) <noppanut.connect@gmail.com>
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -20,6 +21,7 @@ description:
 author:
 - Dag Wieers (@dagwieers)
 - Akini Ross (@akinross)
+- Noppanut Ploywong (@noppanut15)
 options:
   schema:
     description:

--- a/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
@@ -557,7 +557,6 @@
     type: dpc
     primary_micro_segment_vlan: 199
     state: present
-  register: nm_add_stat3e6
   
 # REMOVE STATIC PORT WITHOUT VLAN
 - name: Remove static port 3 (dpc) from EPG6 of AP2 without VLAN (success)

--- a/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
@@ -513,32 +513,6 @@
     that:
     - nm_remove_again_stat2e2 is not changed
 
-# ADD STATIC PORT WITHOUT VLAN
-- name: Add static port 3 (dpc) to EPG6 of AP2 without VLAN (error)
-  cisco.mso.mso_schema_site_anp_epg_staticport:
-    <<: *mso_info
-    schema: '{{ mso_schema | default("ansible_test") }}'
-    site: '{{ mso_site | default("ansible_test") }}'
-    template: Template 1
-    anp: AP2
-    epg: EPG6
-    pod: pod-2
-    leaf: 102
-    path: eth1/3
-    deployment_immediacy: lazy
-    mode: regular
-    type: dpc
-    primary_micro_segment_vlan: 199
-    state: present
-  ignore_errors: true
-  register: nm_add_stat3e6
-
-- name: Verify nm_add_stat3e6
-  ansible.builtin.assert:
-    that:
-    - nm_add_stat3e6 is failed
-    - nm_add_stat3e6.msg == "state is present or absent but all of the following are missing{{":"}} vlan."
-
 # ADD STATIC PORT WITH VLAN
 - name: Add static port 3 (dpc) to EPG6 of AP2 with VLAN (success)
   cisco.mso.mso_schema_site_anp_epg_staticport:
@@ -1237,32 +1211,6 @@
     - nm_remove_static_ports_2.current.7.portEncapVlan == 1205
     - nm_remove_static_ports_2.current.9.path == "topology/pod-1/paths-101/pathep-[eth2/9]"
     - nm_remove_static_ports_2.current.9.portEncapVlan == 1209
-
-# ADD STATIC PORT WITHOUT VLAN (BULK)
-- name: Add static port 3 & 4 (dpc) to epg_bulk of anp_bulk without VLAN (error)
-  cisco.mso.mso_schema_site_anp_epg_staticport:
-    <<: *mso_info
-    schema: '{{ mso_schema | default("ansible_test") }}'
-    site: '{{ mso_site | default("ansible_test") }}'
-    template: template_bulk
-    anp: anp_bulk
-    epg: epg_bulk
-    static_ports:
-      - pod: pod-2
-        leaf: 102
-        path: eth1/3
-        deployment_immediacy: lazy
-        mode: regular
-        type: dpc
-        primary_micro_segment_vlan: 199
-      - pod: pod-2
-        leaf: 102
-        path: eth1/4
-        deployment_immediacy: lazy
-        mode: regular
-        type: dpc
-        primary_micro_segment_vlan: 199
-    state: present
 
 # ADD STATIC PORT WITH VLAN (BULK)
 - name: Add static port 3 & 4 (dpc) to epg_bulk of anp_bulk with VLAN (success)

--- a/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
@@ -558,18 +558,6 @@
     primary_micro_segment_vlan: 199
     state: present
   register: nm_add_stat3e6
-
-- name: Verify nm_add_stat3e6
-  ansible.builtin.assert:
-    that:
-    - nm_add_stat3e6 is changed
-    - nm_add_stat3e6.previous == {}
-    - nm_add_stat3e6.current.deploymentImmediacy == 'lazy'
-    - nm_add_stat3e6.current.portEncapVlan == 100
-    - nm_add_stat3e6.current.microSegVlan == 199
-    - nm_add_stat3e6.current.path == 'topology/pod-2/paths-102/pathep-[eth1/3]'
-    - nm_add_stat3e6.current.mode == 'regular'
-    - nm_add_stat3e6.current.type == 'dpc'
   
 # REMOVE STATIC PORT WITHOUT VLAN
 - name: Remove static port 3 (dpc) from EPG6 of AP2 without VLAN (success)
@@ -1276,14 +1264,6 @@
         type: dpc
         primary_micro_segment_vlan: 199
     state: present
-  ignore_errors: true
-  register: nm_add_stat3e6
-
-- name: Verify nm_add_stat3e6
-  ansible.builtin.assert:
-    that:
-    - nm_add_stat3e6 is failed
-    - nm_add_stat3e6.msg == "state is present but all of the following are missing{{":"}} vlan."
 
 # ADD STATIC PORT WITH VLAN (BULK)
 - name: Add static port 3 & 4 (dpc) to epg_bulk of anp_bulk with VLAN (success)

--- a/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
@@ -512,46 +512,6 @@
   ansible.builtin.assert:
     that:
     - nm_remove_again_stat2e2 is not changed
-
-# ADD STATIC PORT WITH VLAN
-- name: Add static port 3 (dpc) to EPG6 of AP2 with VLAN (success)
-  cisco.mso.mso_schema_site_anp_epg_staticport:
-    <<: *mso_info
-    schema: '{{ mso_schema | default("ansible_test") }}'
-    site: '{{ mso_site | default("ansible_test") }}'
-    template: Template 1
-    anp: AP2
-    epg: EPG6
-    pod: pod-2
-    leaf: 102
-    path: eth1/3
-    vlan: 100
-    deployment_immediacy: lazy
-    mode: regular
-    type: dpc
-    primary_micro_segment_vlan: 199
-    state: present
-  
-# REMOVE STATIC PORT WITHOUT VLAN
-- name: Remove static port 3 (dpc) from EPG6 of AP2 without VLAN (success)
-  cisco.mso.mso_schema_site_anp_epg_staticport:
-    <<: *mso_info
-    schema: '{{ mso_schema | default("ansible_test") }}'
-    site: '{{ mso_site | default("ansible_test") }}'
-    template: Template 1
-    anp: AP2
-    epg: EPG6
-    pod: pod-2
-    leaf: 102
-    path: eth1/3
-    state: absent
-  register: nm_add_stat3e6
-
-- name: Verify nm_add_stat3e6
-  ansible.builtin.assert:
-    that:
-    - nm_add_stat3e6 is changed
-    - nm_add_stat3e6.current == {}
     
 # ADD EXISTING STATIC PORT
 - name: Add static port 1 to site EPG1 again (normal mode)
@@ -1212,103 +1172,6 @@
     - nm_remove_static_ports_2.current.9.path == "topology/pod-1/paths-101/pathep-[eth2/9]"
     - nm_remove_static_ports_2.current.9.portEncapVlan == 1209
 
-# ADD STATIC PORT WITH VLAN (BULK)
-- name: Add static port 3 & 4 (dpc) to epg_bulk of anp_bulk with VLAN (success)
-  cisco.mso.mso_schema_site_anp_epg_staticport:
-    <<: *mso_info
-    schema: '{{ mso_schema | default("ansible_test") }}'
-    site: '{{ mso_site | default("ansible_test") }}'
-    template: template_bulk
-    anp: anp_bulk
-    epg: epg_bulk
-    static_ports:
-      - pod: pod-2
-        leaf: 102
-        path: eth1/3
-        vlan: 100
-        deployment_immediacy: lazy
-        mode: regular
-        type: dpc
-        primary_micro_segment_vlan: 199
-      - pod: pod-2
-        leaf: 102
-        path: eth1/4
-        vlan: 100
-        deployment_immediacy: lazy
-        mode: regular
-        type: dpc
-        primary_micro_segment_vlan: 199
-    state: present
-  register: nm_add_bulk_stat3e6
-
-- name: Verify nm_add_bulk_stat3e6
-  ansible.builtin.assert:
-    that:
-    - nm_add_bulk_stat3e6 is changed
-    - nm_add_bulk_stat3e6.previous | length == 10
-    - nm_add_bulk_stat3e6.previous.0.path == "topology/pod-1/paths-101/pathep-[eth1/1]"
-    - nm_add_bulk_stat3e6.previous.0.portEncapVlan == 1101
-    - nm_add_bulk_stat3e6.previous.2.path == "topology/pod-1/paths-101/pathep-[eth1/5]"
-    - nm_add_bulk_stat3e6.previous.2.portEncapVlan == 1105
-    - nm_add_bulk_stat3e6.previous.4.path == "topology/pod-1/paths-101/pathep-[eth1/9]"
-    - nm_add_bulk_stat3e6.previous.4.portEncapVlan == 1109
-    - nm_add_bulk_stat3e6.previous.5.path == "topology/pod-1/paths-101/pathep-[eth2/1]"
-    - nm_add_bulk_stat3e6.previous.5.portEncapVlan == 1201
-    - nm_add_bulk_stat3e6.previous.7.path == "topology/pod-1/paths-101/pathep-[eth2/5]"
-    - nm_add_bulk_stat3e6.previous.7.portEncapVlan == 1205
-    - nm_add_bulk_stat3e6.previous.9.path == "topology/pod-1/paths-101/pathep-[eth2/9]"
-    - nm_add_bulk_stat3e6.previous.9.portEncapVlan == 1209
-    - nm_add_bulk_stat3e6.current | length == 12
-    - nm_add_bulk_stat3e6.current.10.deploymentImmediacy == 'lazy'
-    - nm_add_bulk_stat3e6.current.10.portEncapVlan == 100
-    - nm_add_bulk_stat3e6.current.10.microSegVlan == 199
-    - nm_add_bulk_stat3e6.current.10.path == 'topology/pod-2/paths-102/pathep-[eth1/3]'
-    - nm_add_bulk_stat3e6.current.10.mode == 'regular'
-    - nm_add_bulk_stat3e6.current.10.type == 'dpc'
-    - nm_add_bulk_stat3e6.current.11.deploymentImmediacy == 'lazy'
-    - nm_add_bulk_stat3e6.current.11.portEncapVlan == 100
-    - nm_add_bulk_stat3e6.current.11.microSegVlan == 199
-    - nm_add_bulk_stat3e6.current.11.path == 'topology/pod-2/paths-102/pathep-[eth1/4]'
-    - nm_add_bulk_stat3e6.current.11.mode == 'regular'
-    - nm_add_bulk_stat3e6.current.11.type == 'dpc'
-  
-# REMOVE STATIC PORT WITHOUT VLAN (BULK)
-- name: Remove static port 3 & 4 (dpc) from epg_bulk of anp_bulk without VLAN (success)
-  cisco.mso.mso_schema_site_anp_epg_staticport:
-    <<: *mso_info
-    schema: '{{ mso_schema | default("ansible_test") }}'
-    site: '{{ mso_site | default("ansible_test") }}'
-    template: template_bulk
-    anp: anp_bulk
-    epg: epg_bulk
-    static_ports:
-      - pod: pod-2
-        leaf: 102
-        path: eth1/3
-      - pod: pod-2
-        leaf: 102
-        path: eth1/4
-    state: absent
-  register: nm_rm_bulk_stat3e6
-
-- name: Verify nm_rm_bulk_stat3e6
-  ansible.builtin.assert:
-    that:
-    - nm_rm_bulk_stat3e6 is changed
-    - nm_rm_bulk_stat3e6.current | length == 10
-    - nm_add_bulk_stat3e6.current.0.path == "topology/pod-1/paths-101/pathep-[eth1/1]"
-    - nm_add_bulk_stat3e6.current.0.portEncapVlan == 1101
-    - nm_add_bulk_stat3e6.current.2.path == "topology/pod-1/paths-101/pathep-[eth1/5]"
-    - nm_add_bulk_stat3e6.current.2.portEncapVlan == 1105
-    - nm_add_bulk_stat3e6.current.4.path == "topology/pod-1/paths-101/pathep-[eth1/9]"
-    - nm_add_bulk_stat3e6.current.4.portEncapVlan == 1109
-    - nm_add_bulk_stat3e6.current.5.path == "topology/pod-1/paths-101/pathep-[eth2/1]"
-    - nm_add_bulk_stat3e6.current.5.portEncapVlan == 1201
-    - nm_add_bulk_stat3e6.current.7.path == "topology/pod-1/paths-101/pathep-[eth2/5]"
-    - nm_add_bulk_stat3e6.current.7.portEncapVlan == 1205
-    - nm_add_bulk_stat3e6.current.9.path == "topology/pod-1/paths-101/pathep-[eth2/9]"
-    - nm_add_bulk_stat3e6.current.9.portEncapVlan == 1209
-
 # FORCE REPLACE TESTS
 
 - name: Force replace static ports with static ports (check_mode)
@@ -1502,6 +1365,74 @@
       - force_remove_all_new_static is changed
       - force_remove_all_new_static.previous == []
       - force_remove_all_new_static.current | length == 1
+
+# WITHOUT VLAN REMOVAL TEST
+- name: Create static ports for without VLAN removal tests
+  cisco.mso.mso_schema_site_anp_epg_staticport:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ mso_site | default("ansible_test") }}'
+    template: template_bulk
+    anp: anp_bulk
+    epg: epg_bulk
+    static_ports:
+      - pod: pod-2
+        leaf: 102
+        path: eth1/1
+        vlan: 101
+      - pod: pod-2
+        leaf: 102
+        path: eth1/2
+        vlan: 102
+      - pod: pod-2
+        leaf: 102
+        path: eth1/3
+        vlan: 103
+    state: present
+
+- name: Remove a static port without VLAN
+  cisco.mso.mso_schema_site_anp_epg_staticport:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ mso_site | default("ansible_test") }}'
+    template: template_bulk
+    anp: anp_bulk
+    epg: epg_bulk
+    pod: pod-2
+    leaf: 102
+    path: eth1/1
+    state: absent
+  register: rm_stat_without_vlan
+
+- name: Verify rm_stat_without_vlan
+  ansible.builtin.assert:
+    that:
+    - rm_stat_without_vlan is changed
+    - rm_stat_without_vlan.current == {}
+
+- name: Remove multiple static ports in bulk without VLAN
+  cisco.mso.mso_schema_site_anp_epg_staticport:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ mso_site | default("ansible_test") }}'
+    template: template_bulk
+    anp: anp_bulk
+    epg: epg_bulk
+    static_ports:
+      - pod: pod-2
+        leaf: 102
+        path: eth1/2
+      - pod: pod-2
+        leaf: 102
+        path: eth1/3
+    state: absent
+  register: rm_bulk_stat_without_vlan
+
+- name: Verify rm_bulk_stat_without_vlan
+  ansible.builtin.assert:
+    that:
+    - rm_bulk_stat_without_vlan is changed
+    - rm_bulk_stat_without_vlan.current == []
 
 # OVERWRITE ARGUMENTS
 

--- a/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
@@ -3,6 +3,7 @@
 # Copyright: (c) 2020, Lionel Hercot (@lhercot) <lhercot@cisco.com>
 # Copyright: (c) 2018, Dag Wieers (@dagwieers) <dag@wieers.com> (based on mso_site test case)
 # Copyright: (c) 2020, Shreyas Srish (@shrsr) <ssrish@cisco.com>
+# Copyright: (c) 2024, Noppanut Ploywong (@noppanut15) <noppanut.connect@gmail.com>
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_staticport/tasks/main.yml
@@ -512,6 +512,85 @@
     that:
     - nm_remove_again_stat2e2 is not changed
 
+# ADD STATIC PORT WITHOUT VLAN
+- name: Add static port 3 (dpc) to EPG6 of AP2 without VLAN (error)
+  cisco.mso.mso_schema_site_anp_epg_staticport:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: AP2
+    epg: EPG6
+    pod: pod-2
+    leaf: 102
+    path: eth1/3
+    deployment_immediacy: lazy
+    mode: regular
+    type: dpc
+    primary_micro_segment_vlan: 199
+    state: present
+  ignore_errors: true
+  register: nm_add_stat3e6
+
+- name: Verify nm_add_stat3e6
+  ansible.builtin.assert:
+    that:
+    - nm_add_stat3e6 is failed
+    - nm_add_stat3e6.msg == "state is present or absent but all of the following are missing{{":"}} vlan."
+
+# ADD STATIC PORT WITH VLAN
+- name: Add static port 3 (dpc) to EPG6 of AP2 with VLAN (success)
+  cisco.mso.mso_schema_site_anp_epg_staticport:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: AP2
+    epg: EPG6
+    pod: pod-2
+    leaf: 102
+    path: eth1/3
+    vlan: 100
+    deployment_immediacy: lazy
+    mode: regular
+    type: dpc
+    primary_micro_segment_vlan: 199
+    state: present
+  register: nm_add_stat3e6
+
+- name: Verify nm_add_stat3e6
+  ansible.builtin.assert:
+    that:
+    - nm_add_stat3e6 is changed
+    - nm_add_stat3e6.previous == {}
+    - nm_add_stat3e6.current.deploymentImmediacy == 'lazy'
+    - nm_add_stat3e6.current.portEncapVlan == 100
+    - nm_add_stat3e6.current.microSegVlan == 199
+    - nm_add_stat3e6.current.path == 'topology/pod-2/paths-102/pathep-[eth1/3]'
+    - nm_add_stat3e6.current.mode == 'regular'
+    - nm_add_stat3e6.current.type == 'dpc'
+  
+# REMOVE STATIC PORT WITHOUT VLAN
+- name: Remove static port 3 (dpc) from EPG6 of AP2 without VLAN (success)
+  cisco.mso.mso_schema_site_anp_epg_staticport:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ mso_site | default("ansible_test") }}'
+    template: Template 1
+    anp: AP2
+    epg: EPG6
+    pod: pod-2
+    leaf: 102
+    path: eth1/3
+    state: absent
+  register: nm_add_stat3e6
+
+- name: Verify nm_add_stat3e6
+  ansible.builtin.assert:
+    that:
+    - nm_add_stat3e6 is changed
+    - nm_add_stat3e6.current == {}
+    
 # ADD EXISTING STATIC PORT
 - name: Add static port 1 to site EPG1 again (normal mode)
   cisco.mso.mso_schema_site_anp_epg_staticport:
@@ -1170,6 +1249,137 @@
     - nm_remove_static_ports_2.current.7.portEncapVlan == 1205
     - nm_remove_static_ports_2.current.9.path == "topology/pod-1/paths-101/pathep-[eth2/9]"
     - nm_remove_static_ports_2.current.9.portEncapVlan == 1209
+
+# ADD STATIC PORT WITHOUT VLAN (BULK)
+- name: Add static port 3 & 4 (dpc) to epg_bulk of anp_bulk without VLAN (error)
+  cisco.mso.mso_schema_site_anp_epg_staticport:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ mso_site | default("ansible_test") }}'
+    template: template_bulk
+    anp: anp_bulk
+    epg: epg_bulk
+    static_ports:
+      - pod: pod-2
+        leaf: 102
+        path: eth1/3
+        deployment_immediacy: lazy
+        mode: regular
+        type: dpc
+        primary_micro_segment_vlan: 199
+      - pod: pod-2
+        leaf: 102
+        path: eth1/4
+        deployment_immediacy: lazy
+        mode: regular
+        type: dpc
+        primary_micro_segment_vlan: 199
+    state: present
+  ignore_errors: true
+  register: nm_add_stat3e6
+
+- name: Verify nm_add_stat3e6
+  ansible.builtin.assert:
+    that:
+    - nm_add_stat3e6 is failed
+    - nm_add_stat3e6.msg == "state is present but all of the following are missing{{":"}} vlan."
+
+# ADD STATIC PORT WITH VLAN (BULK)
+- name: Add static port 3 & 4 (dpc) to epg_bulk of anp_bulk with VLAN (success)
+  cisco.mso.mso_schema_site_anp_epg_staticport:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ mso_site | default("ansible_test") }}'
+    template: template_bulk
+    anp: anp_bulk
+    epg: epg_bulk
+    static_ports:
+      - pod: pod-2
+        leaf: 102
+        path: eth1/3
+        vlan: 100
+        deployment_immediacy: lazy
+        mode: regular
+        type: dpc
+        primary_micro_segment_vlan: 199
+      - pod: pod-2
+        leaf: 102
+        path: eth1/4
+        vlan: 100
+        deployment_immediacy: lazy
+        mode: regular
+        type: dpc
+        primary_micro_segment_vlan: 199
+    state: present
+  register: nm_add_bulk_stat3e6
+
+- name: Verify nm_add_bulk_stat3e6
+  ansible.builtin.assert:
+    that:
+    - nm_add_bulk_stat3e6 is changed
+    - nm_add_bulk_stat3e6.previous | length == 10
+    - nm_add_bulk_stat3e6.previous.0.path == "topology/pod-1/paths-101/pathep-[eth1/1]"
+    - nm_add_bulk_stat3e6.previous.0.portEncapVlan == 1101
+    - nm_add_bulk_stat3e6.previous.2.path == "topology/pod-1/paths-101/pathep-[eth1/5]"
+    - nm_add_bulk_stat3e6.previous.2.portEncapVlan == 1105
+    - nm_add_bulk_stat3e6.previous.4.path == "topology/pod-1/paths-101/pathep-[eth1/9]"
+    - nm_add_bulk_stat3e6.previous.4.portEncapVlan == 1109
+    - nm_add_bulk_stat3e6.previous.5.path == "topology/pod-1/paths-101/pathep-[eth2/1]"
+    - nm_add_bulk_stat3e6.previous.5.portEncapVlan == 1201
+    - nm_add_bulk_stat3e6.previous.7.path == "topology/pod-1/paths-101/pathep-[eth2/5]"
+    - nm_add_bulk_stat3e6.previous.7.portEncapVlan == 1205
+    - nm_add_bulk_stat3e6.previous.9.path == "topology/pod-1/paths-101/pathep-[eth2/9]"
+    - nm_add_bulk_stat3e6.previous.9.portEncapVlan == 1209
+    - nm_add_bulk_stat3e6.current | length == 12
+    - nm_add_bulk_stat3e6.current.10.deploymentImmediacy == 'lazy'
+    - nm_add_bulk_stat3e6.current.10.portEncapVlan == 100
+    - nm_add_bulk_stat3e6.current.10.microSegVlan == 199
+    - nm_add_bulk_stat3e6.current.10.path == 'topology/pod-2/paths-102/pathep-[eth1/3]'
+    - nm_add_bulk_stat3e6.current.10.mode == 'regular'
+    - nm_add_bulk_stat3e6.current.10.type == 'dpc'
+    - nm_add_bulk_stat3e6.current.11.deploymentImmediacy == 'lazy'
+    - nm_add_bulk_stat3e6.current.11.portEncapVlan == 100
+    - nm_add_bulk_stat3e6.current.11.microSegVlan == 199
+    - nm_add_bulk_stat3e6.current.11.path == 'topology/pod-2/paths-102/pathep-[eth1/4]'
+    - nm_add_bulk_stat3e6.current.11.mode == 'regular'
+    - nm_add_bulk_stat3e6.current.11.type == 'dpc'
+  
+# REMOVE STATIC PORT WITHOUT VLAN (BULK)
+- name: Remove static port 3 & 4 (dpc) from epg_bulk of anp_bulk without VLAN (success)
+  cisco.mso.mso_schema_site_anp_epg_staticport:
+    <<: *mso_info
+    schema: '{{ mso_schema | default("ansible_test") }}'
+    site: '{{ mso_site | default("ansible_test") }}'
+    template: template_bulk
+    anp: anp_bulk
+    epg: epg_bulk
+    static_ports:
+      - pod: pod-2
+        leaf: 102
+        path: eth1/3
+      - pod: pod-2
+        leaf: 102
+        path: eth1/4
+    state: absent
+  register: nm_rm_bulk_stat3e6
+
+- name: Verify nm_rm_bulk_stat3e6
+  ansible.builtin.assert:
+    that:
+    - nm_rm_bulk_stat3e6 is changed
+    - nm_rm_bulk_stat3e6.current | length == 10
+    - nm_add_bulk_stat3e6.current.0.path == "topology/pod-1/paths-101/pathep-[eth1/1]"
+    - nm_add_bulk_stat3e6.current.0.portEncapVlan == 1101
+    - nm_add_bulk_stat3e6.current.2.path == "topology/pod-1/paths-101/pathep-[eth1/5]"
+    - nm_add_bulk_stat3e6.current.2.portEncapVlan == 1105
+    - nm_add_bulk_stat3e6.current.4.path == "topology/pod-1/paths-101/pathep-[eth1/9]"
+    - nm_add_bulk_stat3e6.current.4.portEncapVlan == 1109
+    - nm_add_bulk_stat3e6.current.5.path == "topology/pod-1/paths-101/pathep-[eth2/1]"
+    - nm_add_bulk_stat3e6.current.5.portEncapVlan == 1201
+    - nm_add_bulk_stat3e6.current.7.path == "topology/pod-1/paths-101/pathep-[eth2/5]"
+    - nm_add_bulk_stat3e6.current.7.portEncapVlan == 1205
+    - nm_add_bulk_stat3e6.current.9.path == "topology/pod-1/paths-101/pathep-[eth2/9]"
+    - nm_add_bulk_stat3e6.current.9.portEncapVlan == 1209
 
 # FORCE REPLACE TESTS
 


### PR DESCRIPTION
### Description

- Updated the code to make the `vlan` parameter optional when the `state` is `absent`.
- This change ensures that the `vlan` parameter is not required when the state is set to `absent`, preventing potential errors or unnecessary requirements.
- Added appropriate checks to handle the absence of the `vlan` parameter gracefully.

### New or Affected Module(s):

<!--- Please list the new or affected module(s). --->

* `mso_schema_site_anp_epg_staticport`

### MSO version and MSO Platform

* Tested with NDO 4.1


### APIC version and APIC Platform for Site Level Resources

* Tested with APIC 5.2

### Collection versions

* cisco.mso 2.9.0

### References
* Resolves #607

