### PR TITLE
[minor_change] Add module ndo_l3out_routed_interface to configure nodes, routed port and port-channel interfaces in l3out templates (DCNE-428)

### DIFF
--- a/plugins/module_utils/l3out_node.py
+++ b/plugins/module_utils/l3out_node.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, Akini Ross (@akinross) <akinross@cisco.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.cisco.mso.plugins.module_utils.utils import append_update_ops_data, delete_none_values
+
+
+class L3OutNode:
+    def __init__(self, details, mso_l3out_template, l3out_object, pod_id, node_id):
+        self.pod_id = pod_id
+        self.node_id = node_id
+        self.node_router_id = details.get("node_router_id")
+        self.node_group_policy = details.get("node_group_policy")
+        self.use_router_id_as_loopback = details.get("use_router_id_as_loopback")
+        self.node_loopback_ip = details.get("node_loopback_ip")
+        self.node = mso_l3out_template.get_l3out_nodes(l3out_object.details, self.pod_id, self.node_id)
+        self.path = "/l3outTemplate/l3outs/{0}/nodes/{1}".format(l3out_object.index, self.node.index if self.node else "-")
+
+    def construct_node_payload(self):
+        return delete_none_values(
+            {
+                "group": self.node_group_policy,
+                "podID": self.pod_id,
+                "nodeID": self.node_id,
+                "routerID": self.node_router_id,
+                "useRouteIDAsLoopback": self.use_router_id_as_loopback,
+                "loopbackIPs": [self.node_loopback_ip] if self.node_loopback_ip else None,
+            }
+        )
+
+    def update_ops(self, ops):
+        if self.node:
+            self.set_node_replace_ops(ops)
+        else:
+            self.set_node_add_op(ops)
+
+    def set_node_replace_ops(self, ops):
+        remove_data = []
+        node_payload = self.construct_node_payload()
+        if node_payload.get("useRouteIDAsLoopback") is True or node_payload.get("loopbackIPs") == [""]:
+            remove_data.append("loopbackIPs")
+        append_update_ops_data(ops, self.node.details, self.path, node_payload, remove_data)
+
+    def set_node_add_op(self, ops):
+        ops.append(self.get_node_add_op())
+
+    def get_node_add_op(self):
+        return {"op": "add", "path": self.path, "value": delete_none_values(self.construct_node_payload())}
+
+    def get_node_remove_op(self):
+        return {"op": "remove", "path": self.path}

--- a/plugins/module_utils/mso.py
+++ b/plugins/module_utils/mso.py
@@ -298,6 +298,38 @@ def ndo_template_object_spec(aliases=None):
     )
 
 
+def ndo_port_channel_spec():
+    return dict(
+        type="dict",
+        options=dict(
+            uuid=dict(type="str"),
+            reference=dict(
+                type="dict",
+                options=dict(
+                    name=dict(type="str", required=True),
+                    template=dict(type="str"),
+                    template_id=dict(type="str"),
+                ),
+                required_one_of=[
+                    ["template", "template_id"],
+                ],
+                mutually_exclusive=[
+                    ("template", "template_id"),
+                ],
+            ),
+            micro_bfd_enabled=dict(type="bool"),
+            micro_bfd_address=dict(type="str"),
+            micro_bfd_start_timer=dict(type="int"),
+        ),
+        required_one_of=[
+            ["reference", "uuid"],
+        ],
+        mutually_exclusive=[
+            ("reference", "uuid"),
+        ],
+    )
+
+
 # Copied from ansible's module uri.py (url): https://github.com/ansible/ansible/blob/cdf62edc65f564fff6b7e575e084026fa7faa409/lib/ansible/modules/uri.py
 def write_file(module, url, dest, content, resp, tmpsrc=None):
     # create a tempfile with some test content
@@ -680,7 +712,7 @@ class MSOModule(object):
             self.fail_json(msg="Backup file upload failed due to: {0}".format(info))
         return {}
 
-    def request(self, path, method=None, data=None, qs=None, api_version="v1"):
+    def request(self, path, method=None, data=None, qs=None, api_version="v1", ignore_errors=None):
         """Generic HTTP method for MSO requests."""
         self.path = path
 
@@ -798,6 +830,11 @@ class MSOModule(object):
                         payload = body
                     else:
                         payload = json.loads(body)
+
+                    if ignore_errors:
+                        for error in ignore_errors:
+                            if error in payload.get("message", ""):
+                                return error
                 except Exception as e:
                     self.error = dict(code=-1, message="Unable to parse output as JSON, see 'raw' output. %s" % e)
                     self.result["raw"] = body
@@ -813,6 +850,32 @@ class MSOModule(object):
                 self.error = msg
                 self.fail_json(msg=msg)
             return {}
+
+    def l3out_interface_request(self, mso_l3out_template, ops, ignore_errors, state, remove_operation):
+        """
+        Wrapper function to handle the L3Out interface requests and node error responses.
+        L3Out node configuration requires an interface to be present for that node.
+        When the response fails with an error that indicates the node configuration is invalid, this function will retry
+        the request including the removal node configuration.
+        The function will retry only once to avoid potential infinite loops.
+        :param mso_l3out_template: MSOTemplate instance for the L3Out template
+        :param ops: List of operations to send to the API
+        :param ignore_errors: List of error strings to ignore
+        :param state: Desired state of the L3Out interface (present, absent)
+        :param remove_operation: Operation to remove the node configuration if the interface is absent
+        :return: Response from the MSO request
+        """
+
+        if state == "absent":
+            # When the last interface from a node is deleted the node configuration must also be removed
+            response = self.request(mso_l3out_template.template_path, method="PATCH", data=ops, ignore_errors=ignore_errors)
+            # When the response matches an error string from the ignore errors we need to remove the node configuration
+            if response == ignore_errors[0]:
+                ops.append(remove_operation)
+            else:
+                return response
+
+        return self.request(mso_l3out_template.template_path, method="PATCH", data=ops)
 
     def query_objs(self, path, key=None, api_version="v1", **kwargs):
         """Query the MSO REST API for objects in a path"""
@@ -1709,11 +1772,13 @@ class MSOModule(object):
             except ValueError:
                 return self.fail_json(msg="ERROR: The time must be in 'YYYY-MM-DD HH:MM:SS' format.")
 
-    def get_site_interface_details(self, site_id=None, uuid=None, node=None, port=None):
+    def get_site_interface_details(self, site_id=None, uuid=None, node=None, port=None, port_channel_uuid=None):
         if node and port:
             path = "/sitephysifsummary/site/{0}?node={1}".format(site_id, node)
         elif uuid:
             path = "/sitephysifsummary/site/{0}?uuid={1}".format(site_id, uuid)
+        elif port_channel_uuid:
+            path = "/pcsummary/site/{0}?uuid={1}".format(site_id, port_channel_uuid)
 
         site_data = self.request(path, method="GET")
 
@@ -1728,7 +1793,10 @@ class MSOModule(object):
                 if interface.get("port") == port and str(interface.get("node")) == str(node):
                     return interface
             self.fail_json(msg="The site port interface not found. Site ID: {0}, Node: {1} and Path: {2}".format(site_id, node, port))
-
+        elif port_channel_uuid:
+            if site_data.get("spec", {}).get("pcs"):
+                return site_data.get("spec", {}).get("pcs")[0]
+            self.fail_json(msg="The site port channel interface not found. Site ID: {0} and UUID: {1}".format(site_id, port_channel_uuid))
         return {}
 
 

--- a/plugins/module_utils/template.py
+++ b/plugins/module_utils/template.py
@@ -244,11 +244,12 @@ class MSOTemplate:
             )
         return existing_ipsla_policies
 
-    def get_l3out_object(self, uuid=None, name=None, fail_module=False):
+    def get_l3out_object(self, uuid=None, name=None, fail_module=False, search_object=None):
         """
         Get the L3Out by uuid or name.
         :param uuid: UUID of the L3Out to search for -> Str
         :param name: Name of the L3Out to search for -> Str
+        :param search_object: The object to search in -> Dict
         :param fail_module: When match is not found fail the ansible module -> Bool
         :return: Dict | None | List[Dict] | List[]: The processed result which could be:
                  When the UUID | Name is existing in the search list -> Dict
@@ -256,7 +257,9 @@ class MSOTemplate:
                  When both UUID and Name are None, and the search list is not empty -> List[Dict]
                  When both UUID and Name are None, and the search list is empty -> List[]
         """
-        existing_l3outs = self.template.get("l3outTemplate", {}).get("l3outs", [])
+        if not search_object:
+            search_object = self.template
+        existing_l3outs = search_object.get("l3outTemplate", {}).get("l3outs", [])
         if uuid or name:  # Query a specific object
             return self.get_object_by_key_value_pairs("L3Out", existing_l3outs, [KVPair("uuid", uuid) if uuid else KVPair("name", name)], fail_module)
         return existing_l3outs  # Query all objects
@@ -277,6 +280,64 @@ class MSOTemplate:
         if name:  # Query a specific object
             return self.get_object_by_key_value_pairs("L3Out Node Group Policy", existing_l3out_node_groups, [KVPair("name", name)], fail_module)
         return existing_l3out_node_groups  # Query all objects
+
+    def get_port_channel(self, uuid=None, name=None, fail_module=False):
+        """
+        Get the UUID of a port channel by name.
+        :param uuid: UUID of the Port Channel to search for -> Str
+        :param name: Name of the Port Channel to search for -> Str
+        :param fail_module: When match is not found fail the ansible module -> Bool
+
+        """
+        existing_port_channels = self.template.get("fabricResourceTemplate", {}).get("template", {}).get("portChannels", [])
+        if uuid or name:  # Query a specific object
+            return self.get_object_by_key_value_pairs(
+                "Port Channel", existing_port_channels, [KVPair("uuid", uuid)] if uuid else [KVPair("name", name)], fail_module=fail_module
+            )
+        return existing_port_channels
+
+    def get_l3out_nodes(self, l3out_object, pod_id, node_id, fail_module=False):
+        """
+        Get the L3Out Nodes by pod_id and node_id.
+        :param l3out_object: L3Out object to search for the Routed Interface -> Dict
+        :param pod_id: Pod ID of the Routed Interface to search for -> Str
+        :param node_id: Node ID of the Routed Interface to search for -> Str
+        :param fail_module: When match is not found fail the ansible module -> Bool
+        :return: Dict | None | List[Dict] | List[]: The processed result which could be:
+                 When the Name is existing in the search list -> Dict
+                 When the Name is not existing in the search list -> None
+                 When the Name is None, and the search list is not empty -> List[Dict]
+                 When the Name is None, and the search list is empty -> List[]
+        """
+        existing_l3out_nodes = l3out_object.get("nodes", [])
+        if pod_id and node_id:  # Query a specific object
+            return self.get_object_by_key_value_pairs("L3Out Nodes", existing_l3out_nodes, [KVPair("podID", pod_id), KVPair("nodeID", node_id)], fail_module)
+        return existing_l3out_nodes  # Query all objects
+
+    def get_l3out_routed_interfaces(self, l3out_object, pod_id, node_id, path, path_ref, fail_module=False):
+        """
+        Get the L3Out Routed Interface by pod_id, node_id, path, and path_ref.
+        :param l3out_object: L3Out object to search for the Routed Interface -> Dict
+        :param pod_id: Pod ID of the Routed Interface to search for -> Str
+        :param node_id: Node ID of the Routed Interface to search for -> Str
+        :param path: Path of the Routed Interface to search for -> Str
+        :param path_ref: Path reference of the Routed Interface to search for -> Str
+        :param fail_module: When match is not found fail the ansible module -> Bool
+        :return: Dict | None | List[Dict] | List[]: The processed result which could be:
+                 When the Name is existing in the search list -> Dict
+                 When the Name is not existing in the search list -> None
+                 When the Name is None, and the search list is not empty -> List[Dict]
+                 When the Name is None, and the search list is empty -> List[]
+        """
+        existing_l3out_interfaces = l3out_object.get("interfaces", [])
+        if (pod_id and node_id and path) or path_ref:  # Query a specific object
+            if path_ref:
+                kv_list = [KVPair("pathRef", path_ref)]
+            else:
+                kv_list = [KVPair("podID", pod_id), KVPair("nodeID", node_id), KVPair("path", path)]
+
+            return self.get_object_by_key_value_pairs("L3Out Interfaces", existing_l3out_interfaces, kv_list, fail_module)
+        return existing_l3out_interfaces  # Query all objects
 
     def get_node_settings_object(self, uuid=None, name=None, fail_module=False):
         """
@@ -473,6 +534,42 @@ class MSOTemplate:
                         if isinstance(item, dict):
                             self.update_config_with_template_and_references(item, reference_collections, False, use_cache)
         return config_data
+
+    def update_config_with_port_channel_references(self, update_object):
+        if update_object:
+            reference_details = None
+            if update_object.get("pathRef"):
+                reference_details = {
+                    "port_channel_reference": {
+                        "name": "portChannelName",
+                        "reference": "pathRef",
+                        "type": "portChannel",
+                        "template": "portChannelTemplateName",
+                        "templateId": "portChannelTemplateId",
+                    }
+                }
+            self.update_config_with_template_and_references(
+                update_object,
+                reference_details,
+                True,
+            )
+
+    def update_config_with_node_references(self, interface, l3out_object):
+
+        pod_id = interface.get("podID")
+        node_id = interface.get("nodeID")
+
+        if interface.get("pathType") == "pc":
+            interface_details = self.mso.get_site_interface_details(
+                self.template.get("l3outTemplate", {}).get("siteId"),
+                port_channel_uuid=interface.get("pathRef"),
+            )
+            pod_id = interface_details.get("pod")
+            node_id = interface_details.get("node")
+
+        node = self.get_l3out_nodes(l3out_object.details, pod_id, node_id)
+        if node and not isinstance(node, list):
+            interface["node"] = node.details
 
     def check_template_when_name_is_provided(self, parameter):
         if parameter and parameter.get("name") and not (parameter.get("template") or parameter.get("template_id")):

--- a/plugins/modules/ndo_l3out_routed_interface.py
+++ b/plugins/modules/ndo_l3out_routed_interface.py
@@ -1,0 +1,544 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, Akini Ross (@akinross) <akinross@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: ndo_l3out_routed_interface
+short_description: Manage L3Out Routed Interfaces on Cisco Nexus Dashboard Orchestrator (NDO).
+description:
+- Manage L3Out Routed Interfaces on Cisco Nexus Dashboard Orchestrator (NDO).
+- This module is only supported on ND v3.1 (NDO v4.3) and later.
+author:
+- Akini Ross (@akinross)
+options:
+  template:
+    description:
+    - The name of the template.
+    - The template must be an L3Out template.
+    - This parameter or O(template_id) is required.
+    type: str
+    aliases: [ l3out_template ]
+  template_id:
+    description:
+    - The ID of the L3Out template.
+    - This parameter or O(template) is required.
+    type: str
+    aliases: [ l3out_template_id ]
+  l3out:
+    description:
+    - The name of the L3Out.
+    - This parameter or O(l3out_uuid) is required.
+    type: str
+    aliases: [ l3out_name ]
+  l3out_uuid:
+    description:
+    - The UUID of the L3Out.
+    - This parameter or O(l3out) is required.
+    type: str
+  node_id:
+    description:
+    - The ID of the node (border leaf switch) where to deploy the L3Out routing protocol and node-level protocol configurations.
+    - This parameter is required when O(path) is specified.
+    - The node configuration is created under the L3Out template when it does not exist.
+    - The node configuration is updated under the L3Out template when it already exists.
+    - The node configuration is deleted under the L3Out template when there are no interfaces referencing it.
+    type: str
+    aliases: [ node, border_leaf ]
+  node_router_id:
+    description:
+    - The router ID of the node.
+    type: str
+    aliases: [ router_id ]
+  node_group_policy:
+    description:
+    - The name of the node group policy.
+    type: str
+  use_router_id_as_loopback:
+    description:
+    - Whether to use the router ID as the loopback address of the node.
+    type: bool
+  node_loopback_ip:
+    description:
+    - The loopback IP address of the node.
+    type: str
+    aliases: [ loopback_ip ]
+  path:
+    description:
+    - The path of the interface.
+    - The path is an existing physical port (eth1/1).
+    - This parameter is mutually exclusive with O(port_channel).
+    type: str
+    aliases: [ interface ]
+  port_channel:
+    description:
+    - The port channel details.
+    - This parameter is mutually exclusive with O(path).
+    type: dict
+    suboptions:
+      uuid:
+        description:
+        - The UUID of the port channel.
+        - This parameter or O(port_channel.reference) is required.
+        type: str
+      reference:
+        description:
+        - The reference details of the port channel.
+        - This parameter or O(port_channel.uuid) is required.
+        type: dict
+        suboptions:
+          name:
+            description:
+            - The name of the port channel.
+            type: str
+            required: true
+          template:
+            description:
+            - The name of the template that contains the port channel.
+            - This parameter or O(port_channel.reference.template_id) is required.
+            type: str
+          template_id:
+            description:
+            - The ID of the template that contains the port channel.
+            - This parameter or O(port_channel.reference.template) is required.
+            type: str
+      micro_bfd_enabled:
+        description:
+        - Whether to enable micro BFD (Bidirectional Forwarding Detection) on the interface.
+        type: bool
+      micro_bfd_address:
+        description:
+        - The address for micro BFD.
+        type: str
+      micro_bfd_start_timer:
+        description:
+        - The start timer for micro BFD.
+        - The value must be 0 or in the range 60 - 3600.
+        type: int
+  interface_group_policy:
+    description:
+    - The name of the interface group policy.
+    type: str
+  ipv4_address:
+    description:
+    - The IPv4 address of the interface.
+    type: str
+  ipv6_address:
+    description:
+    - The IPv6 address of the interface.
+    type: str
+  ipv6_link_local_address:
+    description:
+    - The IPv6 link-local address of the interface.
+    type: str
+  ipv6_dad:
+    description:
+    - Whether to enable IPv6 Duplicate Address Detection (DAD).
+    - If this parameter is unspecified, NDO defaults to O(ipv6_dad=enabled).
+    type: str
+    choices: [ enabled, disabled ]
+  mac:
+    description:
+    - The MAC address of the interface.
+    type: str
+  mtu:
+    description:
+    - The Maximum Transmission Unit (MTU) of the interface.
+    - Use O(mtu=inherit) to inherit the value configured under the fabric L2 MTU settings.
+    - The value must be 1, in the range 576 - 9216 or O(mtu=inherit).
+    type: str
+  target_dscp:
+    description:
+    - The target Differentiated Services Code Point (DSCP) of the interface.
+    - If this parameter is unspecified, NDO defaults to O(target_dscp=unspecified).
+    type: str
+    choices:
+    - af11
+    - af12
+    - af13
+    - af21
+    - af22
+    - af23
+    - af31
+    - af32
+    - af33
+    - af41
+    - af42
+    - af43
+    - cs0
+    - cs1
+    - cs2
+    - cs3
+    - cs4
+    - cs5
+    - cs6
+    - cs7
+    - expedited_forwarding
+    - unspecified
+    - voice_admit
+  state:
+    description:
+    - Determines the desired state of the resource.
+    - Use C(absent) to remove the resource.
+    - Use C(query) to list the resource.
+    - Use C(present) to create or update the resource.
+    type: str
+    choices: [ absent, query, present ]
+    default: query
+notes:
+- The O(template) or O(template_id) must exist before using this module in your playbook.
+  The M(cisco.mso.ndo_template) module can be used for this.
+- The O(l3out) or O(l3out_uuid) must exist before using this module in your playbook.
+  The M(cisco.mso.ndo_l3out_template) module can be used for this.
+seealso:
+- module: cisco.mso.ndo_template
+- module: cisco.mso.ndo_l3out_template
+extends_documentation_fragment: cisco.mso.modules
+"""
+
+EXAMPLES = r"""
+- name: Create a L3Out Routed Interface of type port
+  cisco.mso.ndo_l3out_routed_interface:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    template: l3out_template
+    l3out: l3out_name
+    ipv4_address: 10.0.0.1/24
+    ipv6_address: 2::101/16
+    ipv6_link_local_address: FE80::10
+    ipv6_dad: enabled
+    mac: 00:22:BD:F8:19:FF
+    mtu: inherit
+    node_id: 101
+    path: eth1/1
+    interface_group_policy: interface_group_policy_name
+    node_router_id: 1.1.1.1
+    node_group_policy: node_group_policy_name
+    use_router_id_as_loopback: true
+    state: present
+
+- name: Create a L3Out Routed Interface of type port_channel with reference
+  cisco.mso.ndo_l3out_routed_interface:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    template: l3out_template
+    l3out: l3out_name
+    ipv4_address: 10.1.0.1/24
+    ipv6_address: 1::112/16
+    ipv6_link_local_address: FE80::20
+    ipv6_dad: disabled
+    mac: 00:22:BD:F8:19:EE
+    mtu: 2000
+    port_channel:
+      micro_bfd_enabled: true
+      micro_bfd_address: 1::110
+      micro_bfd_start_timer: 60
+      reference:
+        name: port_channel_interface_name
+        template: fabric_resource_template_name
+    interface_group_policy: interface_group_policy_name
+    node_router_id: 2.2.2.2
+    node_group_policy: node_group_policy_name
+    use_router_id_as_loopback: false
+    node_loopback_ip: 10.0.0.1
+    state: present
+
+- name: Update a L3Out Routed Interface of type port_channel with uuid
+  cisco.mso.ndo_l3out_routed_interface:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    template_id: "{{ l3out_template.current.templateId }}"
+    l3out_uuid: "{{ l3out.current.uuid }}"
+    ipv4_address: 10.1.0.1/24
+    ipv6_address: 1::112/16
+    ipv6_link_local_address: FE80::20
+    ipv6_dad: disabled
+    mac: 00:22:BD:F8:19:EE
+    mtu: 2000
+    port_channel:
+      micro_bfd_enabled: true
+      micro_bfd_address: 1::110
+      micro_bfd_start_timer: 60
+      uuid: "{{ port_channel_interface.current.uuid }}"
+    interface_group_policy: interface_group_policy_name
+    node_router_id: 2.2.2.2
+    node_group_policy: node_group_policy_name
+    use_router_id_as_loopback: false
+    node_loopback_ip: 10.0.0.1
+    state: present
+
+- name: Query an existing L3Out Routed Interface of type port
+  cisco.mso.ndo_l3out_routed_interface:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    template: l3out_template
+    l3out: l3out_name
+    node_id: 101
+    path: eth1/1
+    state: query
+  register: query_with_name
+
+- name: Query an existing L3Out Routed Interface of type port_channel
+  cisco.mso.ndo_l3out_routed_interface:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    template: l3out_template
+    l3out: l3out_name
+    port_channel:
+      reference:
+        name: port_channel_interface_name
+        template: fabric_resource_template_name
+    state: query
+  register: query_with_name
+
+- name: Query all existing Routed Interfaces of a L3Out
+  cisco.mso.ndo_l3out_routed_interface:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    template: l3out_template
+    l3out: l3out_name
+    state: query
+
+- name: Delete an existing L3Out Routed Interface
+  cisco.mso.ndo_l3out_routed_interface:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    template: l3out_template
+    l3out: l3out_name
+    node_id: 101
+    path: eth1/1
+    state: absent
+"""
+
+RETURN = r"""
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec, ndo_port_channel_spec
+from ansible_collections.cisco.mso.plugins.module_utils.templates import MSOTemplates
+from ansible_collections.cisco.mso.plugins.module_utils.constants import TARGET_DSCP_MAP
+from ansible_collections.cisco.mso.plugins.module_utils.utils import append_update_ops_data, delete_none_values
+from ansible_collections.cisco.mso.plugins.module_utils.l3out_node import L3OutNode
+import copy
+
+
+def main():
+    argument_spec = mso_argument_spec()
+    argument_spec.update(
+        template=dict(type="str", aliases=["l3out_template"]),
+        template_id=dict(type="str", aliases=["l3out_template_id"]),
+        l3out=dict(type="str", aliases=["l3out_name"]),
+        l3out_uuid=dict(type="str"),
+        node_id=dict(type="str", aliases=["node", "border_leaf"]),
+        node_group_policy=dict(type="str"),
+        node_router_id=dict(type="str", aliases=["router_id"]),
+        use_router_id_as_loopback=dict(type="bool"),
+        node_loopback_ip=dict(type="str", aliases=["loopback_ip"]),
+        path=dict(type="str", aliases=["interface"]),
+        port_channel=ndo_port_channel_spec(),
+        interface_group_policy=dict(type="str"),
+        ipv4_address=dict(type="str"),
+        ipv6_address=dict(type="str"),
+        ipv6_link_local_address=dict(type="str"),
+        ipv6_dad=dict(type="str", choices=["enabled", "disabled"]),
+        mac=dict(type="str"),
+        mtu=dict(type="str"),
+        target_dscp=dict(type="str", choices=list(TARGET_DSCP_MAP)),
+        state=dict(type="str", default="query", choices=["absent", "query", "present"]),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ["state", "present", ["path", "port_channel"], True],
+            ["state", "absent", ["path", "port_channel"], True],
+        ],
+        required_by={
+            "path": "node_id",
+        },
+        required_one_of=[
+            ["template", "template_id"],
+            ["l3out", "l3out_uuid"],
+        ],
+        mutually_exclusive=[
+            ["template", "template_id"],
+            ["l3out", "l3out_uuid"],
+            ["port_channel", "path"],
+            ["port_channel", "node_id"],
+        ],
+    )
+
+    mso = MSOModule(module)
+    mso_templates = MSOTemplates(mso)
+
+    template_name = mso.params.get("template")
+    template_id = mso.params.get("template_id")
+    l3out = mso.params.get("l3out")
+    l3out_uuid = mso.params.get("l3out_uuid")
+    node_id = mso.params.get("node_id")
+    node_router_id = mso.params.get("node_router_id")
+    node_group_policy = mso.params.get("node_group_policy")
+    use_router_id_as_loopback = mso.params.get("use_router_id_as_loopback")
+    node_loopback_ip = mso.params.get("node_loopback_ip")
+    path = mso.params.get("path")
+    port_channel = mso.params.get("port_channel")
+    interface_group_policy = mso.params.get("interface_group_policy")
+    ipv4_address = mso.params.get("ipv4_address")
+    ipv6_address = mso.params.get("ipv6_address")
+    ipv6_link_local_address = mso.params.get("ipv6_link_local_address")
+    ipv6_dad = mso.params.get("ipv6_dad")
+    mac = mso.params.get("mac")
+    mtu = mso.params.get("mtu")
+    target_dscp = mso.params.get("target_dscp")
+    state = mso.params.get("state")
+
+    mso_l3out_template = mso_templates.get_template("l3out", template_name, template_id)
+    mso_l3out_template.validate_template("l3out")
+    l3out_object = mso_l3out_template.get_l3out_object(l3out_uuid, l3out, True)
+
+    port_channel_uuid = None
+    if port_channel:
+        if port_channel.get("uuid"):
+            port_channel_uuid = port_channel.get("uuid")
+            port_channel_match = mso_l3out_template.get_template_object_by_uuid("portChannel", port_channel_uuid, True)
+            node_id = port_channel_match.get("node")
+        else:
+            fabric_resource_template = mso_templates.get_template(
+                "fabric_resource",
+                port_channel.get("reference").get("template"),
+                port_channel.get("reference").get("template_id"),
+            )
+            port_channel_match = fabric_resource_template.get_port_channel(
+                port_channel_uuid,
+                port_channel.get("reference").get("name"),
+                fail_module=True,
+            )
+            port_channel_uuid = port_channel_match.details.get("uuid")
+            node_id = port_channel_match.details.get("node")
+
+    pod_id = None
+    if path or port_channel:
+        pod_id = mso.get_site_interface_details(
+            site_id=mso_l3out_template.template.get("l3outTemplate", {}).get("siteId"),
+            node=node_id,
+            port=path,
+            port_channel_uuid=port_channel_uuid,
+        ).get("pod")
+
+    match = mso_l3out_template.get_l3out_routed_interfaces(l3out_object.details, pod_id, node_id, path, port_channel_uuid)
+    if (path or port_channel) and match:
+        set_routed_interface_details(mso_l3out_template, match.details, l3out_object)
+        mso.existing = mso.previous = copy.deepcopy(match.details)  # Query a specific object
+    elif match:
+        mso.existing = [set_routed_interface_details(mso_l3out_template, obj, l3out_object) for obj in match]
+
+    l3out_interface_path = "/l3outTemplate/l3outs/{0}/interfaces/{1}".format(l3out_object.index, match.index if match else "-")
+
+    ops = []
+
+    if state != "query":
+        l3out_node = L3OutNode(mso.params, mso_l3out_template, l3out_object, pod_id, node_id)
+
+    if state == "present":
+
+        mso_values = {
+            "path": path,
+            "pathRef": port_channel_uuid,
+            "pathType": "port" if path else "pc",
+            "group": interface_group_policy,
+            "mac": mac,
+            "mtu": mtu,
+            "targetDscp": target_dscp,
+        }
+
+        if path:
+            mso_values["nodeID"] = node_id
+            mso_values["podID"] = pod_id
+
+        if match:
+            remove_data = []
+            mso_values[("addresses", "primaryV4")] = ipv4_address
+            mso_values[("addresses", "primaryV6")] = ipv6_address
+            mso_values[("addresses", "linkLocalV6")] = ipv6_link_local_address
+            mso_values[("addresses", "ipV6DAD")] = ipv6_dad
+
+            if port_channel and port_channel.get("micro_bfd_enabled") is False:
+                remove_data.append("microBfd")
+            elif port_channel and port_channel.get("micro_bfd_enabled"):
+                if not match.details.get("microBfd"):
+                    mso_values["microBfd"] = {}
+                mso_values[("microBfd", "address")] = port_channel.get("micro_bfd_address")
+                mso_values[("microBfd", "startTimer")] = port_channel.get("micro_bfd_start_timer")
+
+            append_update_ops_data(ops, match.details, l3out_interface_path, mso_values, remove_data)
+            mso.sanitize(match.details, collate=True, unwanted=remove_data)
+
+        else:
+            mso_values["addresses"] = {
+                "primaryV4": ipv4_address,
+                "primaryV6": ipv6_address,
+                "linkLocalV6": ipv6_link_local_address,
+                "ipV6DAD": ipv6_dad,
+            }
+
+            if port_channel and port_channel.get("micro_bfd_enabled") is True:
+                mso_values["microBfd"] = {
+                    "address": port_channel.get("micro_bfd_address"),
+                    "startTimer": port_channel.get("micro_bfd_start_timer"),
+                }
+
+            mso_values = delete_none_values(mso_values)
+            mso.sanitize(mso_values)
+            ops.append(dict(op="add", path=l3out_interface_path, value=mso.sent))
+
+            # update mso.proposed with interface details that are not included in the interface payload and node details
+            mso.proposed["node"] = l3out_node.construct_node_payload()
+            set_routed_interface_details(mso_l3out_template, mso.proposed, l3out_object)
+
+        l3out_node.update_ops(ops)
+
+    elif state == "absent":
+        if match:
+            ops.append(dict(op="remove", path=l3out_interface_path))
+
+    if not mso.module.check_mode and ops:
+        ignore_errors = ["node {0}-{1} doesn't have an interface configured".format(pod_id, node_id)]
+        response = mso.l3out_interface_request(mso_l3out_template, ops, ignore_errors, state, l3out_node.get_node_remove_op())
+        l3out_object = mso_l3out_template.get_l3out_object(l3out_uuid, l3out, True, search_object=response)
+        match = mso_l3out_template.get_l3out_routed_interfaces(l3out_object.details, pod_id, node_id, path, port_channel_uuid)
+        if match:
+            set_routed_interface_details(mso_l3out_template, match.details, l3out_object)
+            mso.existing = match.details  # When the state is present
+        else:
+            mso.existing = {}  # When the state is absent
+    elif mso.module.check_mode and state != "query":  # When the state is present/absent with check mode
+        mso.existing = mso.proposed if state == "present" else {}
+    mso.exit_json()
+
+
+def set_routed_interface_details(mso_template, routed_interface, l3out_object):
+    mso_template.update_config_with_port_channel_references(routed_interface)
+    mso_template.update_config_with_node_references(routed_interface, l3out_object)
+    return routed_interface
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/ndo_l3out_routed_interface/aliases
+++ b/tests/integration/targets/ndo_l3out_routed_interface/aliases
@@ -1,0 +1,2 @@
+# No ACI MultiSite infrastructure, so not enabled
+# unsupported

--- a/tests/integration/targets/ndo_l3out_routed_interface/tasks/main.yml
+++ b/tests/integration/targets/ndo_l3out_routed_interface/tasks/main.yml
@@ -1,0 +1,1037 @@
+# Test code for the MSO modules
+# Copyright: (c) 2025, Akini Ross (@akinross) <akinross@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI MultiSite host, username and password
+  ansible.builtin.fail:
+    msg: "Please define the following variables: mso_hostname, mso_username and mso_password."
+  when: mso_hostname is not defined or mso_username is not defined or mso_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    mso_info: &mso_info
+      host: "{{ mso_hostname }}"
+      username: "{{ mso_username }}"
+      password: "{{ mso_password }}"
+      validate_certs: "{{ mso_validate_certs | default(false) }}"
+      use_ssl: "{{ mso_use_ssl | default(true) }}"
+      use_proxy: "{{ mso_use_proxy | default(true) }}"
+      output_level: '{{ mso_output_level | default("debug") }}'
+
+# QUERY VERSION
+- name: Query MSO version
+  cisco.mso.mso_version:
+    <<: *mso_info
+    state: query
+  register: version
+
+- name: Execute tasks only for NDO version >= 4.4
+  when: version.current.version is version('4.4', '>=')
+  block:
+    
+    # CLEAN ENVIRONMENT - ENSURE CLEAN ENVIRONMENT FOR TESTS
+    # TODO: move to a separate task file for re-use
+
+    - name: Ensure ansible_test tenant exist
+      cisco.mso.mso_tenant: &mso_tenant_present
+        <<: *mso_info
+        tenant: '{{ mso_tenant | default("ansible_test") }}'
+        users:
+          - '{{ mso_username }}'
+        sites:
+          - '{{ mso_site | default("ansible_test") }}'
+        state: present
+
+    - name: Ensure L3out template does not exist
+      cisco.mso.ndo_template: &ndo_l3out_template_absent
+        <<: *mso_info
+        template: '{{ mso_l3out_template | default("ansible_test") }}'
+        template_type: l3out
+        tenant: '{{ mso_tenant | default("ansible_test") }}'
+        sites:
+          - name: '{{ mso_site | default("ansible_test") }}'
+        state: absent
+
+    - name: Ensure ansible_test schema does not exist
+      cisco.mso.mso_schema_template: &mso_schema_template_absent
+        <<: *mso_info
+        schema: '{{ mso_schema | default("ansible_test") }}'
+        tenant: '{{ mso_tenant | default("ansible_test") }}'
+        template: template_1
+        state: absent
+
+    - name: Ensure ansible_fabric_resource_template does not exist
+      cisco.mso.ndo_template: &ndo_fabric_resource_template_absent
+        <<: *mso_info
+        name: '{{ mso_fabric_resource_template | default("ansible_test") }}'
+        template_type: fabric_resource
+        sites:
+          - name: '{{ mso_site | default("ansible_test") }}'
+        state: absent
+    
+    - name: Ensure ansible_fabric_policy_template does not exist
+      cisco.mso.ndo_template: &ndo_fabric_policy_template_absent
+        <<: *mso_info
+        name: '{{ mso_fabric_policy_template | default("ansible_test") }}'
+        template_type: fabric_policy
+        sites:
+          - name: '{{ mso_site | default("ansible_test") }}'
+        state: absent
+
+    # CLEAN ENVIRONMENT - REQUIRED FOR TESTS
+
+    - name: Create a fabric_policy template
+      cisco.mso.ndo_template:
+        <<: *ndo_fabric_policy_template_absent
+        state: present
+
+    - name: Create a VLAN pool in the fabric_policy template
+      cisco.mso.ndo_vlan_pool:
+        <<: *mso_info
+        template: '{{ mso_fabric_policy_template | default("ansible_test") }}'
+        vlan_pool: ansible_test_vlan_pool_1
+        vlan_ranges:
+          - from_vlan: 100
+            to_vlan: 200
+        state: present
+
+    - name: Create a L3 domain in the fabric_policy template
+      cisco.mso.ndo_l3_domain:
+        <<: *mso_info
+        template: '{{ mso_fabric_policy_template | default("ansible_test") }}'
+        l3_domain: ansible_test_l3_domain
+        pool: ansible_test_vlan_pool_1
+        state: present
+
+    - name: Create a interface policy group of type port channel
+      cisco.mso.ndo_interface_setting:
+        <<: *mso_info
+        template: '{{ mso_fabric_policy_template | default("ansible_test") }}'
+        name: ansible_test_interface_policy_group_port_channel
+        interface_type: port_channel
+        state: present
+
+    - name: Create a fabric_resource template
+      cisco.mso.ndo_template:
+        <<: *ndo_fabric_resource_template_absent
+        state: present
+    
+    - name: Create port_channel_interface_1 in the fabric_resource template
+      cisco.mso.ndo_port_channel_interface:
+        <<: *mso_info
+        template: '{{ mso_fabric_resource_template | default("ansible_test") }}'
+        port_channel_interface: ansible_port_channel_interface_1
+        node: 101
+        interfaces: 1/20
+        interface_policy_group:
+          template: '{{ mso_fabric_policy_template | default("ansible_test") }}'
+          name: ansible_test_interface_policy_group_port_channel
+        state: present
+      register: port_channel_interface_1
+
+    - name: Create port_channel_interface_2 in the fabric_resource template
+      cisco.mso.ndo_port_channel_interface:
+        <<: *mso_info
+        template: '{{ mso_fabric_resource_template | default("ansible_test") }}'
+        port_channel_interface: ansible_port_channel_interface_2
+        node: 102
+        interfaces: 1/20
+        interface_policy_group:
+          template: '{{ mso_fabric_policy_template | default("ansible_test") }}'
+          name: ansible_test_interface_policy_group_port_channel
+        state: present
+      register: port_channel_interface_2
+
+    - name: Create a schema template
+      cisco.mso.mso_schema_template:
+        <<: *mso_schema_template_absent
+        state: present
+
+    - name: Create a VRF in the schema template
+      cisco.mso.mso_schema_template_vrf:
+        <<: *mso_info
+        schema: '{{ mso_schema | default("ansible_test") }}'
+        template: template_1
+        vrf: vrf_1
+        state: present
+
+    - name: Create a new L3Out template
+      cisco.mso.ndo_template:
+        <<: *ndo_l3out_template_absent
+        state: present
+
+    - name: Create L3Out object in the L3Out template
+      cisco.mso.ndo_l3out_template:
+        <<: *mso_info
+        l3out_template: '{{ mso_l3out_template | default("ansible_test") }}'
+        name: l3out_1
+        vrf:
+          name: vrf_1
+          schema: '{{ mso_schema | default("ansible_test") }}'
+          template: template_1
+        l3_domain: ansible_test_l3_domain
+        ospf:
+          state: enabled
+          area_id: 0.0.0.1
+          area_type: regular
+        bgp:
+          state: enabled
+        state: present
+
+    - name: Create L3Out node group policy
+      cisco.mso.ndo_l3out_node_group_policy:
+        <<: *mso_info
+        template: '{{ mso_l3out_template | default("ansible_test") }}'
+        l3out: l3out_1
+        name: node_group_policy_1
+        state: present
+    
+    - name: Create L3Out interface group policy
+      cisco.mso.ndo_l3out_interface_group_policy:
+        <<: *mso_info
+        template: '{{ mso_l3out_template | default("ansible_test") }}'
+        l3out: l3out_1
+        name: interface_group_policy_1
+        state: present
+
+    # CREATE
+
+    - name: Create a L3out routed interface of type port (check mode)
+      cisco.mso.ndo_l3out_routed_interface: &create_routed_interface
+        <<: *mso_info
+        template: '{{ mso_l3out_template | default("ansible_test") }}'
+        l3out: l3out_1
+        node_id: 101
+        path: eth1/1
+        ipv4_address: 10.0.0.1/24
+        mac: 00:22:BD:F8:19:FF
+        mtu: inherit
+        node_router_id: 1.1.1.1
+        state: present
+      check_mode: true
+      register: cm_create_routed_interface
+
+    - name: Create a L3out routed interface of type port
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface
+        state: present
+      register: nm_create_routed_interface
+    
+    - name: Create a L3out routed interface of type port again
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface
+        state: present
+      register: nm_create_routed_interface_again
+    
+    - name: Assert that the L3out routed interface of type port was created
+      ansible.builtin.assert:
+        that:
+          - cm_create_routed_interface is changed
+          - cm_create_routed_interface.previous == {}
+          - cm_create_routed_interface.proposed.podID == "1"
+          - cm_create_routed_interface.proposed.nodeID == "101"
+          - cm_create_routed_interface.proposed.path == "eth1/1"
+          - cm_create_routed_interface.proposed.pathRef is not defined
+          - cm_create_routed_interface.proposed.pathType == "port"
+          - cm_create_routed_interface.proposed.templateId is defined
+          - cm_create_routed_interface.proposed.templateName is defined
+          - cm_create_routed_interface.proposed.mtu == "inherit"
+          - cm_create_routed_interface.proposed.mac == "00:22:BD:F8:19:FF"
+          - cm_create_routed_interface.proposed.group is not defined
+          - cm_create_routed_interface.proposed.targetDscp is not defined
+          - cm_create_routed_interface.proposed.addresses.primaryV4 == "10.0.0.1/24"
+          - cm_create_routed_interface.proposed.addresses.primaryV6 is not defined
+          - cm_create_routed_interface.proposed.addresses.linkLocalV6 is not defined
+          - cm_create_routed_interface.proposed.addresses.ipV6DAD is not defined
+          - cm_create_routed_interface.proposed.node.nodeID == "101"
+          - cm_create_routed_interface.proposed.node.podID == "1"
+          - cm_create_routed_interface.proposed.node.routerID == "1.1.1.1"
+          - cm_create_routed_interface.proposed.node.useRouteIDAsLoopback is not defined
+          - cm_create_routed_interface.proposed.node.loopbackIPs is not defined
+          - cm_create_routed_interface.proposed.node.group is not defined
+          - cm_create_routed_interface.proposed == cm_create_routed_interface.current
+          - nm_create_routed_interface is changed
+          - nm_create_routed_interface.previous == {}
+          - nm_create_routed_interface.proposed.podID == "1"
+          - nm_create_routed_interface.proposed.nodeID == "101"
+          - nm_create_routed_interface.proposed.path == "eth1/1"
+          - nm_create_routed_interface.proposed.pathRef is not defined
+          - nm_create_routed_interface.proposed.pathType == "port"
+          - nm_create_routed_interface.proposed.templateId is defined
+          - nm_create_routed_interface.proposed.templateName is defined
+          - nm_create_routed_interface.proposed.mtu == "inherit"
+          - nm_create_routed_interface.proposed.mac == "00:22:BD:F8:19:FF"
+          - nm_create_routed_interface.proposed.group is not defined
+          - nm_create_routed_interface.proposed.targetDscp is not defined
+          - nm_create_routed_interface.proposed.addresses.primaryV4 == "10.0.0.1/24"
+          - nm_create_routed_interface.proposed.addresses.primaryV6 is not defined
+          - nm_create_routed_interface.proposed.addresses.linkLocalV6 is not defined
+          - nm_create_routed_interface.proposed.addresses.ipV6DAD is not defined
+          - nm_create_routed_interface.proposed.node.nodeID == "101"
+          - nm_create_routed_interface.proposed.node.podID == "1"
+          - nm_create_routed_interface.proposed.node.routerID == "1.1.1.1"
+          - nm_create_routed_interface.proposed.node.useRouteIDAsLoopback is not defined
+          - nm_create_routed_interface.proposed.node.loopbackIPs is not defined
+          - nm_create_routed_interface.proposed.node.group is not defined
+          - nm_create_routed_interface.current != nm_create_routed_interface.proposed
+          - nm_create_routed_interface.current.podID == "1"
+          - nm_create_routed_interface.current.nodeID == "101"
+          - nm_create_routed_interface.current.path == "eth1/1"
+          - nm_create_routed_interface.current.pathRef is not defined
+          - nm_create_routed_interface.current.pathType == "port"
+          - nm_create_routed_interface.current.templateId is defined
+          - nm_create_routed_interface.current.templateName is defined
+          - nm_create_routed_interface.current.mtu == "inherit"
+          - nm_create_routed_interface.current.mac == "00:22:BD:F8:19:FF"
+          - nm_create_routed_interface.current.group == ""
+          - nm_create_routed_interface.current.targetDscp == "unspecified"
+          - nm_create_routed_interface.current.addresses.primaryV4 == "10.0.0.1/24"
+          - nm_create_routed_interface.current.addresses.primaryV6 is not defined
+          - nm_create_routed_interface.current.addresses.linkLocalV6 is not defined
+          - nm_create_routed_interface.current.addresses.ipV6DAD == "enabled"
+          - nm_create_routed_interface.current.node.nodeID == "101"
+          - nm_create_routed_interface.current.node.podID == "1"
+          - nm_create_routed_interface.current.node.routerID == "1.1.1.1"
+          - nm_create_routed_interface.current.node.useRouteIDAsLoopback == false
+          - nm_create_routed_interface.current.node.loopbackIPs is not defined
+          - nm_create_routed_interface.current.node.group == ""
+          - nm_create_routed_interface_again is not changed
+          - nm_create_routed_interface_again.previous == nm_create_routed_interface_again.proposed == nm_create_routed_interface_again.current
+          - nm_create_routed_interface_again.current.podID == "1"
+          - nm_create_routed_interface_again.current.nodeID == "101"
+          - nm_create_routed_interface_again.current.path == "eth1/1"
+          - nm_create_routed_interface_again.current.pathRef is not defined
+          - nm_create_routed_interface_again.current.pathType == "port"
+          - nm_create_routed_interface_again.current.templateId is defined
+          - nm_create_routed_interface_again.current.templateName is defined
+          - nm_create_routed_interface_again.current.mtu == "inherit"
+          - nm_create_routed_interface_again.current.mac == "00:22:BD:F8:19:FF"
+          - nm_create_routed_interface_again.current.group == ""
+          - nm_create_routed_interface_again.current.targetDscp == "unspecified"
+          - nm_create_routed_interface_again.current.addresses.primaryV4 == "10.0.0.1/24"
+          - nm_create_routed_interface_again.current.addresses.primaryV6 is not defined
+          - nm_create_routed_interface_again.current.addresses.linkLocalV6 is not defined
+          - nm_create_routed_interface_again.current.addresses.ipV6DAD == "enabled"
+          - nm_create_routed_interface_again.current.node.nodeID == "101"
+          - nm_create_routed_interface_again.current.node.podID == "1"
+          - nm_create_routed_interface_again.current.node.routerID == "1.1.1.1"
+          - nm_create_routed_interface_again.current.node.useRouteIDAsLoopback == false
+          - nm_create_routed_interface_again.current.node.loopbackIPs is not defined
+          - nm_create_routed_interface_again.current.node.group == ""
+
+    - name: Create a L3out routed interface of type port channel with uuid (check mode)
+      cisco.mso.ndo_l3out_routed_interface: &create_routed_interface_port_channel_uuid
+        <<: *mso_info
+        template: '{{ mso_l3out_template | default("ansible_test") }}'
+        l3out: l3out_1
+        port_channel:
+          uuid: '{{ port_channel_interface_1.current.uuid }}'
+        ipv6_address: 1::101/16
+        ipv6_dad: disabled
+        mac: 00:22:BD:F8:19:EE
+        mtu: 2000
+        state: present
+      check_mode: true
+      register: cm_create_routed_interface_port_channel_uuid
+    
+    - name: Create a L3out routed interface of type port channel
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface_port_channel_uuid
+        state: present
+      register: nm_create_routed_interface_port_channel_uuid
+    
+    - name: Create a L3out routed interface of type port channel again
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface_port_channel_uuid
+        state: present
+      register: nm_create_routed_interface_port_channel_uuid_again
+    
+    - name: Assert that the L3out routed interface of type port channel was created
+      ansible.builtin.assert:
+        that:
+          - cm_create_routed_interface_port_channel_uuid is changed
+          - cm_create_routed_interface_port_channel_uuid.previous == {}
+          - cm_create_routed_interface_port_channel_uuid.proposed.podID is not defined
+          - cm_create_routed_interface_port_channel_uuid.proposed.nodeID is not defined
+          - cm_create_routed_interface_port_channel_uuid.proposed.path is not defined
+          - cm_create_routed_interface_port_channel_uuid.proposed.pathRef is defined
+          - cm_create_routed_interface_port_channel_uuid.proposed.pathType == "pc"
+          - cm_create_routed_interface_port_channel_uuid.proposed.portChannelName == "ansible_port_channel_interface_1"
+          - cm_create_routed_interface_port_channel_uuid.proposed.portChannelTemplateId is defined
+          - cm_create_routed_interface_port_channel_uuid.proposed.portChannelTemplateName is defined
+          - cm_create_routed_interface_port_channel_uuid.proposed.templateId is defined
+          - cm_create_routed_interface_port_channel_uuid.proposed.templateName is defined
+          - cm_create_routed_interface_port_channel_uuid.proposed.mtu == "2000"
+          - cm_create_routed_interface_port_channel_uuid.proposed.mac == "00:22:BD:F8:19:EE"
+          - cm_create_routed_interface_port_channel_uuid.proposed.group is not defined
+          - cm_create_routed_interface_port_channel_uuid.proposed.targetDscp is not defined
+          - cm_create_routed_interface_port_channel_uuid.proposed.addresses.primaryV4 is not defined
+          - cm_create_routed_interface_port_channel_uuid.proposed.addresses.primaryV6 == "1::101/16"
+          - cm_create_routed_interface_port_channel_uuid.proposed.addresses.linkLocalV6 is not defined
+          - cm_create_routed_interface_port_channel_uuid.proposed.addresses.ipV6DAD == "disabled"
+          - cm_create_routed_interface_port_channel_uuid.proposed.node.nodeID == "101"
+          - cm_create_routed_interface_port_channel_uuid.proposed.node.podID == "1"
+          - cm_create_routed_interface_port_channel_uuid.proposed.node.routerID == "1.1.1.1"
+          - cm_create_routed_interface_port_channel_uuid.proposed.node.useRouteIDAsLoopback == false
+          - cm_create_routed_interface_port_channel_uuid.proposed.node.loopbackIPs is not defined
+          - cm_create_routed_interface_port_channel_uuid.proposed.node.group == ""
+          - cm_create_routed_interface_port_channel_uuid.proposed.microBfd is not defined
+          - cm_create_routed_interface_port_channel_uuid.proposed == cm_create_routed_interface_port_channel_uuid.current
+          - nm_create_routed_interface_port_channel_uuid is changed
+          - nm_create_routed_interface_port_channel_uuid.proposed.podID is not defined
+          - nm_create_routed_interface_port_channel_uuid.proposed.nodeID is not defined
+          - nm_create_routed_interface_port_channel_uuid.proposed.path is not defined
+          - nm_create_routed_interface_port_channel_uuid.proposed.pathRef is defined
+          - nm_create_routed_interface_port_channel_uuid.proposed.pathType == "pc"
+          - nm_create_routed_interface_port_channel_uuid.proposed.portChannelName == "ansible_port_channel_interface_1"
+          - nm_create_routed_interface_port_channel_uuid.proposed.portChannelTemplateId is defined
+          - nm_create_routed_interface_port_channel_uuid.proposed.portChannelTemplateName is defined
+          - nm_create_routed_interface_port_channel_uuid.proposed.templateId is defined
+          - nm_create_routed_interface_port_channel_uuid.proposed.templateName is defined
+          - nm_create_routed_interface_port_channel_uuid.proposed.mtu == "2000"
+          - nm_create_routed_interface_port_channel_uuid.proposed.mac == "00:22:BD:F8:19:EE"
+          - nm_create_routed_interface_port_channel_uuid.proposed.group is not defined
+          - nm_create_routed_interface_port_channel_uuid.proposed.targetDscp is not defined
+          - nm_create_routed_interface_port_channel_uuid.proposed.addresses.primaryV4 is not defined
+          - nm_create_routed_interface_port_channel_uuid.proposed.addresses.primaryV6 == "1::101/16"
+          - nm_create_routed_interface_port_channel_uuid.proposed.addresses.linkLocalV6 is not defined
+          - nm_create_routed_interface_port_channel_uuid.proposed.addresses.ipV6DAD == "disabled"
+          - nm_create_routed_interface_port_channel_uuid.proposed.node.nodeID == "101"
+          - nm_create_routed_interface_port_channel_uuid.proposed.node.podID == "1"
+          - nm_create_routed_interface_port_channel_uuid.proposed.node.routerID == "1.1.1.1"
+          - nm_create_routed_interface_port_channel_uuid.proposed.node.useRouteIDAsLoopback == false
+          - nm_create_routed_interface_port_channel_uuid.proposed.node.loopbackIPs is not defined
+          - nm_create_routed_interface_port_channel_uuid.proposed.node.group == ""
+          - nm_create_routed_interface_port_channel_uuid.proposed.microBfd is not defined
+          - nm_create_routed_interface_port_channel_uuid.current != nm_create_routed_interface_port_channel_uuid.proposed
+          - nm_create_routed_interface_port_channel_uuid.current.podID is not defined
+          - nm_create_routed_interface_port_channel_uuid.current.nodeID is not defined
+          - nm_create_routed_interface_port_channel_uuid.current.path is not defined
+          - nm_create_routed_interface_port_channel_uuid.current.pathRef is defined
+          - nm_create_routed_interface_port_channel_uuid.current.pathType == "pc"
+          - nm_create_routed_interface_port_channel_uuid.current.portChannelName == "ansible_port_channel_interface_1"
+          - nm_create_routed_interface_port_channel_uuid.current.portChannelTemplateId is defined
+          - nm_create_routed_interface_port_channel_uuid.current.portChannelTemplateName is defined
+          - nm_create_routed_interface_port_channel_uuid.current.templateId is defined
+          - nm_create_routed_interface_port_channel_uuid.current.templateName is defined
+          - nm_create_routed_interface_port_channel_uuid.current.mtu == "2000"
+          - nm_create_routed_interface_port_channel_uuid.current.mac == "00:22:BD:F8:19:EE"
+          - nm_create_routed_interface_port_channel_uuid.current.group == ""
+          - nm_create_routed_interface_port_channel_uuid.current.targetDscp == "unspecified"
+          - nm_create_routed_interface_port_channel_uuid.current.addresses.primaryV4 is not defined
+          - nm_create_routed_interface_port_channel_uuid.current.addresses.primaryV6 == "1::101/16"
+          - nm_create_routed_interface_port_channel_uuid.current.addresses.linkLocalV6 is not defined
+          - nm_create_routed_interface_port_channel_uuid.current.addresses.ipV6DAD == "disabled"
+          - nm_create_routed_interface_port_channel_uuid.current.node.nodeID == "101"
+          - nm_create_routed_interface_port_channel_uuid.current.node.podID == "1"
+          - nm_create_routed_interface_port_channel_uuid.current.node.routerID == "1.1.1.1"
+          - nm_create_routed_interface_port_channel_uuid.current.node.useRouteIDAsLoopback == false
+          - nm_create_routed_interface_port_channel_uuid.current.node.loopbackIPs is not defined
+          - nm_create_routed_interface_port_channel_uuid.current.node.group == ""
+          - nm_create_routed_interface_port_channel_uuid.current.microBfd is not defined
+          - nm_create_routed_interface_port_channel_uuid_again is not changed
+          - nm_create_routed_interface_port_channel_uuid_again.previous == nm_create_routed_interface_port_channel_uuid_again.proposed == nm_create_routed_interface_port_channel_uuid_again.current
+          - nm_create_routed_interface_port_channel_uuid_again.current.podID is not defined
+          - nm_create_routed_interface_port_channel_uuid_again.current.nodeID is not defined
+          - nm_create_routed_interface_port_channel_uuid_again.current.path is not defined
+          - nm_create_routed_interface_port_channel_uuid_again.current.pathRef is defined
+          - nm_create_routed_interface_port_channel_uuid_again.current.pathType == "pc"
+          - nm_create_routed_interface_port_channel_uuid_again.current.portChannelName == "ansible_port_channel_interface_1"
+          - nm_create_routed_interface_port_channel_uuid_again.current.portChannelTemplateId is defined
+          - nm_create_routed_interface_port_channel_uuid_again.current.portChannelTemplateName is defined
+          - nm_create_routed_interface_port_channel_uuid_again.current.templateId is defined
+          - nm_create_routed_interface_port_channel_uuid_again.current.templateName is defined
+          - nm_create_routed_interface_port_channel_uuid_again.current.mtu == "2000"
+          - nm_create_routed_interface_port_channel_uuid_again.current.mac == "00:22:BD:F8:19:EE"
+          - nm_create_routed_interface_port_channel_uuid_again.current.group == ""
+          - nm_create_routed_interface_port_channel_uuid_again.current.targetDscp == "unspecified"
+          - nm_create_routed_interface_port_channel_uuid_again.current.addresses.primaryV4 is not defined
+          - nm_create_routed_interface_port_channel_uuid_again.current.addresses.primaryV6 == "1::101/16"
+          - nm_create_routed_interface_port_channel_uuid_again.current.addresses.linkLocalV6 is not defined
+          - nm_create_routed_interface_port_channel_uuid_again.current.addresses.ipV6DAD == "disabled"
+          - nm_create_routed_interface_port_channel_uuid_again.current.node.nodeID == "101"
+          - nm_create_routed_interface_port_channel_uuid_again.current.node.podID == "1"
+          - nm_create_routed_interface_port_channel_uuid_again.current.node.routerID == "1.1.1.1"
+          - nm_create_routed_interface_port_channel_uuid_again.current.node.useRouteIDAsLoopback == false
+          - nm_create_routed_interface_port_channel_uuid_again.current.node.loopbackIPs is not defined
+          - nm_create_routed_interface_port_channel_uuid_again.current.node.group == ""
+          - nm_create_routed_interface_port_channel_uuid_again.current.microBfd is not defined
+
+    - name: Create a L3out routed interface of type port channel with reference and micro bfd
+      cisco.mso.ndo_l3out_routed_interface: &create_routed_interface_port_channel_reference
+        <<: *mso_info
+        template: '{{ mso_l3out_template | default("ansible_test") }}'
+        l3out: l3out_1
+        node_router_id: 2.2.2.2
+        use_router_id_as_loopback: true
+        port_channel:
+          micro_bfd_enabled: true
+          micro_bfd_address: 1::110
+          micro_bfd_start_timer: 60
+          reference:
+            name: '{{ port_channel_interface_2.current.name }}'
+            template: '{{ mso_fabric_resource_template | default("ansible_test") }}'
+        ipv6_address: 1::102/16
+        mac: 00:22:BD:F8:19:EE
+        mtu: 2000
+        state: present
+      register: nm_create_routed_interface_port_channel_reference_micro_bfd
+
+    - name: Assert that the L3out routed interface of type port channel with reference and micro bfd was created
+      ansible.builtin.assert:
+        that:
+          - nm_create_routed_interface_port_channel_reference_micro_bfd is changed
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.previous == {}
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.podID is not defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.nodeID is not defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.path is not defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.pathRef is defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.pathType == "pc"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.portChannelName == "ansible_port_channel_interface_2"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.portChannelTemplateId is defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.portChannelTemplateName is defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.templateId is defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.templateName is defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.mtu == "2000"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.mac == "00:22:BD:F8:19:EE"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.group is not defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.targetDscp is not defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.microBfd.address == "1::110"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.microBfd.startTimer == 60
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.addresses.primaryV4 is not defined 
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.addresses.primaryV6 == "1::102/16"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.addresses.linkLocalV6 is not defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.addresses.ipV6DAD is not defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.node.nodeID == "102"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.node.podID == "1"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.node.routerID == "2.2.2.2"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.node.useRouteIDAsLoopback == true
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.node.loopbackIPs is not defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.proposed.node.group is not defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current != nm_create_routed_interface_port_channel_reference_micro_bfd.proposed
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.podID is not defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.nodeID is not defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.path is not defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.pathRef is defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.pathType == "pc"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.portChannelName == "ansible_port_channel_interface_2"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.portChannelTemplateId is defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.portChannelTemplateName is defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.templateId is defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.templateName is defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.mtu == "2000"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.mac == "00:22:BD:F8:19:EE"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.group == ""
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.targetDscp == "unspecified"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.microBfd.address == "1::110"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.microBfd.startTimer == 60
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.addresses.primaryV4 is not defined 
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.addresses.primaryV6 == "1::102/16"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.addresses.linkLocalV6 is not defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.addresses.ipV6DAD == "enabled"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.node.nodeID == "102"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.node.podID == "1"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.node.routerID == "2.2.2.2"
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.node.useRouteIDAsLoopback == true
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.node.loopbackIPs is not defined
+          - nm_create_routed_interface_port_channel_reference_micro_bfd.current.node.group == ""
+
+    # UPDATE
+
+    - name: Update a L3out routed interface of type port (check mode)
+      cisco.mso.ndo_l3out_routed_interface: &update_routed_interface
+        <<: *create_routed_interface
+        ipv4_address: 10.0.0.2/24
+        ipv6_address: 2::101/16
+        ipv6_link_local_address: FE80::10
+        ipv6_dad: enabled
+        mac: 00:22:BD:F8:19:FE
+        mtu: 1000
+        node_group_policy: node_group_policy_1
+        interface_group_policy: interface_group_policy_1
+        target_dscp: af11
+      check_mode: true
+      register: cm_update_routed_interface_port
+
+    - name: Update a L3out routed interface of type port
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *update_routed_interface
+      register: nm_update_routed_interface_port
+    
+    - name: Update a L3out routed interface of type port again
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *update_routed_interface
+      register: nm_update_routed_interface_port_again
+    
+    - name: Assert that the L3out routed interface of type port was updated
+      ansible.builtin.assert:
+        that:
+          - cm_update_routed_interface_port is changed
+          - cm_update_routed_interface_port.previous == nm_create_routed_interface_again.current
+          - cm_update_routed_interface_port.previous != cm_update_routed_interface_port.proposed
+          - cm_update_routed_interface_port.proposed == cm_update_routed_interface_port.current
+          - cm_update_routed_interface_port.proposed.podID == "1"
+          - cm_update_routed_interface_port.proposed.nodeID == "101"
+          - cm_update_routed_interface_port.proposed.path == "eth1/1"
+          - cm_update_routed_interface_port.proposed.pathRef is not defined
+          - cm_update_routed_interface_port.proposed.pathType == "port"
+          - cm_update_routed_interface_port.proposed.templateId is defined
+          - cm_update_routed_interface_port.proposed.templateName is defined
+          - cm_update_routed_interface_port.proposed.mtu == "1000"
+          - cm_update_routed_interface_port.proposed.mac == "00:22:BD:F8:19:FE"
+          - cm_update_routed_interface_port.proposed.group == "interface_group_policy_1"
+          - cm_update_routed_interface_port.proposed.targetDscp == "af11"
+          - cm_update_routed_interface_port.proposed.addresses.primaryV4 == "10.0.0.2/24"
+          - cm_update_routed_interface_port.proposed.addresses.primaryV6 == "2::101/16"
+          - cm_update_routed_interface_port.proposed.addresses.linkLocalV6 == "FE80::10"
+          - cm_update_routed_interface_port.proposed.addresses.ipV6DAD == "enabled"
+          - cm_update_routed_interface_port.proposed.node.nodeID == "101"
+          - cm_update_routed_interface_port.proposed.node.podID == "1"
+          - cm_update_routed_interface_port.proposed.node.routerID == "1.1.1.1"
+          - cm_update_routed_interface_port.proposed.node.useRouteIDAsLoopback == false
+          - cm_update_routed_interface_port.proposed.node.loopbackIPs is not defined
+          - cm_update_routed_interface_port.proposed.node.group == "node_group_policy_1"
+          - nm_update_routed_interface_port is changed
+          - nm_update_routed_interface_port.previous == nm_create_routed_interface_again.current
+          - nm_update_routed_interface_port.previous != nm_update_routed_interface_port.current
+          - nm_update_routed_interface_port.current == nm_update_routed_interface_port.proposed
+          - nm_update_routed_interface_port.current.podID == "1"
+          - nm_update_routed_interface_port.current.nodeID == "101"
+          - nm_update_routed_interface_port.current.path == "eth1/1"
+          - nm_update_routed_interface_port.current.pathRef is not defined
+          - nm_update_routed_interface_port.current.pathType == "port"
+          - nm_update_routed_interface_port.current.templateId is defined
+          - nm_update_routed_interface_port.current.templateName is defined
+          - nm_update_routed_interface_port.current.mtu == "1000"
+          - nm_update_routed_interface_port.current.mac == "00:22:BD:F8:19:FE"
+          - nm_update_routed_interface_port.current.group == "interface_group_policy_1"
+          - nm_update_routed_interface_port.current.targetDscp == "af11"
+          - nm_update_routed_interface_port.current.addresses.primaryV4 == "10.0.0.2/24"
+          - nm_update_routed_interface_port.current.addresses.primaryV6 == "2::101/16"
+          - nm_update_routed_interface_port.current.addresses.linkLocalV6 == "FE80::10"
+          - nm_update_routed_interface_port.current.addresses.ipV6DAD == "enabled"
+          - nm_update_routed_interface_port.current.node.nodeID == "101"
+          - nm_update_routed_interface_port.current.node.podID == "1"
+          - nm_update_routed_interface_port.current.node.routerID == "1.1.1.1"
+          - nm_update_routed_interface_port.current.node.useRouteIDAsLoopback == false
+          - nm_update_routed_interface_port.current.node.loopbackIPs is not defined
+          - nm_update_routed_interface_port.current.node.group == "node_group_policy_1"
+          - nm_update_routed_interface_port_again is not changed
+          - nm_update_routed_interface_port_again.previous == nm_update_routed_interface_port_again.proposed == nm_update_routed_interface_port_again.current
+          - nm_update_routed_interface_port_again.current.podID == "1"
+          - nm_update_routed_interface_port_again.current.nodeID == "101"
+          - nm_update_routed_interface_port_again.current.path == "eth1/1"
+          - nm_update_routed_interface_port_again.current.pathRef is not defined
+          - nm_update_routed_interface_port_again.current.pathType == "port"
+          - nm_update_routed_interface_port_again.current.templateId is defined
+          - nm_update_routed_interface_port_again.current.templateName is defined
+          - nm_update_routed_interface_port_again.current.mtu == "1000"
+          - nm_update_routed_interface_port_again.current.mac == "00:22:BD:F8:19:FE"
+          - nm_update_routed_interface_port_again.current.group == "interface_group_policy_1"
+          - nm_update_routed_interface_port_again.current.targetDscp == "af11"
+          - nm_update_routed_interface_port_again.current.addresses.primaryV4 == "10.0.0.2/24"
+          - nm_update_routed_interface_port_again.current.addresses.primaryV6 == "2::101/16"
+          - nm_update_routed_interface_port_again.current.addresses.linkLocalV6 == "FE80::10"
+          - nm_update_routed_interface_port_again.current.addresses.ipV6DAD == "enabled"
+          - nm_update_routed_interface_port_again.current.node.nodeID == "101"
+          - nm_update_routed_interface_port_again.current.node.podID == "1"
+          - nm_update_routed_interface_port_again.current.node.routerID == "1.1.1.1"
+          - nm_update_routed_interface_port_again.current.node.useRouteIDAsLoopback == false
+          - nm_update_routed_interface_port_again.current.node.loopbackIPs is not defined
+          - nm_update_routed_interface_port_again.current.node.group == "node_group_policy_1"
+
+    - name: Update a L3out routed interface of type port channel with uuid (check mode)
+      cisco.mso.ndo_l3out_routed_interface: &update_routed_interface_port_channel_uuid
+        <<: *create_routed_interface_port_channel_uuid
+        ipv4_address: 10.1.0.3/24
+        ipv6_address: 1::112/16
+        ipv6_link_local_address: FE80::20
+        ipv6_dad: enabled
+        mac: 00:22:BD:F8:19:EE
+        mtu: 1500
+        node_group_policy: node_group_policy_1
+        interface_group_policy: interface_group_policy_1
+        target_dscp: cs5
+      check_mode: true
+      register: cm_update_routed_interface_port_channel_uuid
+
+    - name: Update a L3out routed interface of type port channel
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *update_routed_interface_port_channel_uuid
+      register: nm_update_routed_interface_port_channel_uuid
+    
+    - name: Update a L3out routed interface of type port channel again
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *update_routed_interface_port_channel_uuid
+      register: nm_update_routed_interface_port_channel_uuid_again
+    
+    - name: Assert that the L3out routed interface of type port channel was updated
+      ansible.builtin.assert:
+        that:
+          - cm_update_routed_interface_port_channel_uuid is changed
+          - cm_update_routed_interface_port_channel_uuid.previous != nm_create_routed_interface_port_channel_uuid_again.proposed
+          - cm_update_routed_interface_port_channel_uuid.proposed == cm_update_routed_interface_port_channel_uuid.current
+          - cm_update_routed_interface_port_channel_uuid.proposed.podID is not defined
+          - cm_update_routed_interface_port_channel_uuid.proposed.nodeID is not defined
+          - cm_update_routed_interface_port_channel_uuid.proposed.path is not defined
+          - cm_update_routed_interface_port_channel_uuid.proposed.pathRef is defined
+          - cm_update_routed_interface_port_channel_uuid.proposed.pathType == "pc"
+          - cm_update_routed_interface_port_channel_uuid.proposed.portChannelName == "ansible_port_channel_interface_1"
+          - cm_update_routed_interface_port_channel_uuid.proposed.portChannelTemplateId is defined
+          - cm_update_routed_interface_port_channel_uuid.proposed.portChannelTemplateName is defined
+          - cm_update_routed_interface_port_channel_uuid.proposed.templateId is defined
+          - cm_update_routed_interface_port_channel_uuid.proposed.templateName is defined
+          - cm_update_routed_interface_port_channel_uuid.proposed.mtu == "1500"
+          - cm_update_routed_interface_port_channel_uuid.proposed.mac == "00:22:BD:F8:19:EE"
+          - cm_update_routed_interface_port_channel_uuid.proposed.group == "interface_group_policy_1"
+          - cm_update_routed_interface_port_channel_uuid.proposed.targetDscp == "cs5"
+          - cm_update_routed_interface_port_channel_uuid.proposed.microBfd is not defined
+          - cm_update_routed_interface_port_channel_uuid.proposed.addresses.primaryV4 == "10.1.0.3/24"
+          - cm_update_routed_interface_port_channel_uuid.proposed.addresses.primaryV6 == "1::112/16"
+          - cm_update_routed_interface_port_channel_uuid.proposed.addresses.linkLocalV6 == "FE80::20"
+          - cm_update_routed_interface_port_channel_uuid.proposed.addresses.ipV6DAD == "enabled"
+          - cm_update_routed_interface_port_channel_uuid.proposed.node.nodeID == "101"
+          - cm_update_routed_interface_port_channel_uuid.proposed.node.podID == "1"
+          - cm_update_routed_interface_port_channel_uuid.proposed.node.routerID == "1.1.1.1"
+          - cm_update_routed_interface_port_channel_uuid.proposed.node.useRouteIDAsLoopback == false
+          - cm_update_routed_interface_port_channel_uuid.proposed.node.loopbackIPs is not defined
+          - cm_update_routed_interface_port_channel_uuid.proposed.node.group == "node_group_policy_1"
+          - nm_update_routed_interface_port_channel_uuid is changed
+          - nm_update_routed_interface_port_channel_uuid.previous != nm_create_routed_interface_port_channel_uuid_again.current
+          - nm_update_routed_interface_port_channel_uuid.current == nm_update_routed_interface_port_channel_uuid.proposed
+          - nm_update_routed_interface_port_channel_uuid.current.podID is not defined
+          - nm_update_routed_interface_port_channel_uuid.current.nodeID is not defined
+          - nm_update_routed_interface_port_channel_uuid.current.path is not defined
+          - nm_update_routed_interface_port_channel_uuid.current.pathRef is defined
+          - nm_update_routed_interface_port_channel_uuid.current.pathType == "pc"
+          - nm_update_routed_interface_port_channel_uuid.current.portChannelName == "ansible_port_channel_interface_1"
+          - nm_update_routed_interface_port_channel_uuid.current.portChannelTemplateId is defined
+          - nm_update_routed_interface_port_channel_uuid.current.portChannelTemplateName is defined
+          - nm_update_routed_interface_port_channel_uuid.current.templateId is defined
+          - nm_update_routed_interface_port_channel_uuid.current.templateName is defined
+          - nm_update_routed_interface_port_channel_uuid.current.mtu == "1500"
+          - nm_update_routed_interface_port_channel_uuid.current.mac == "00:22:BD:F8:19:EE"
+          - nm_update_routed_interface_port_channel_uuid.current.group == "interface_group_policy_1"
+          - nm_update_routed_interface_port_channel_uuid.current.targetDscp == "cs5"
+          - nm_update_routed_interface_port_channel_uuid.current.microBfd is not defined
+          - nm_update_routed_interface_port_channel_uuid.current.addresses.primaryV4 == "10.1.0.3/24"
+          - nm_update_routed_interface_port_channel_uuid.current.addresses.primaryV6 == "1::112/16"
+          - nm_update_routed_interface_port_channel_uuid.current.addresses.linkLocalV6 == "FE80::20"
+          - nm_update_routed_interface_port_channel_uuid.current.addresses.ipV6DAD == "enabled"
+          - nm_update_routed_interface_port_channel_uuid.current.node.nodeID == "101"
+          - nm_update_routed_interface_port_channel_uuid.current.node.podID == "1"
+          - nm_update_routed_interface_port_channel_uuid.current.node.routerID == "1.1.1.1"
+          - nm_update_routed_interface_port_channel_uuid.current.node.useRouteIDAsLoopback == false
+          - nm_update_routed_interface_port_channel_uuid.current.node.loopbackIPs is not defined
+          - nm_update_routed_interface_port_channel_uuid.current.node.group == "node_group_policy_1"
+          - nm_update_routed_interface_port_channel_uuid_again is not changed
+          - nm_update_routed_interface_port_channel_uuid_again.previous == nm_update_routed_interface_port_channel_uuid_again.proposed == nm_update_routed_interface_port_channel_uuid_again.current
+          - nm_update_routed_interface_port_channel_uuid_again.current.podID is not defined
+          - nm_update_routed_interface_port_channel_uuid_again.current.nodeID is not defined
+          - nm_update_routed_interface_port_channel_uuid_again.current.path is not defined
+          - nm_update_routed_interface_port_channel_uuid_again.current.pathRef is defined
+          - nm_update_routed_interface_port_channel_uuid_again.current.pathType == "pc"
+          - nm_update_routed_interface_port_channel_uuid_again.current.portChannelName == "ansible_port_channel_interface_1"
+          - nm_update_routed_interface_port_channel_uuid_again.current.portChannelTemplateId is defined
+          - nm_update_routed_interface_port_channel_uuid_again.current.portChannelTemplateName is defined
+          - nm_update_routed_interface_port_channel_uuid_again.current.templateId is defined
+          - nm_update_routed_interface_port_channel_uuid_again.current.templateName is defined
+          - nm_update_routed_interface_port_channel_uuid_again.current.mtu == "1500"
+          - nm_update_routed_interface_port_channel_uuid_again.current.mac == "00:22:BD:F8:19:EE"
+          - nm_update_routed_interface_port_channel_uuid_again.current.group == "interface_group_policy_1"
+          - nm_update_routed_interface_port_channel_uuid_again.current.targetDscp == "cs5"
+          - nm_update_routed_interface_port_channel_uuid_again.current.microBfd is not defined
+          - nm_update_routed_interface_port_channel_uuid_again.current.addresses.primaryV4 == "10.1.0.3/24"
+          - nm_update_routed_interface_port_channel_uuid_again.current.addresses.primaryV6 == "1::112/16"
+          - nm_update_routed_interface_port_channel_uuid_again.current.addresses.linkLocalV6 == "FE80::20"
+          - nm_update_routed_interface_port_channel_uuid_again.current.addresses.ipV6DAD == "enabled"
+          - nm_update_routed_interface_port_channel_uuid_again.current.node.nodeID == "101"
+          - nm_update_routed_interface_port_channel_uuid_again.current.node.podID == "1"
+          - nm_update_routed_interface_port_channel_uuid_again.current.node.routerID == "1.1.1.1"
+          - nm_update_routed_interface_port_channel_uuid_again.current.node.useRouteIDAsLoopback == false
+          - nm_update_routed_interface_port_channel_uuid_again.current.node.loopbackIPs is not defined
+          - nm_update_routed_interface_port_channel_uuid_again.current.node.group == "node_group_policy_1"
+
+    - name: Remove the ipv4_address from a L3out routed interface
+      cisco.mso.ndo_l3out_routed_interface: &removed_ipv4_address
+        <<: *update_routed_interface
+        ipv4_address: ''
+      register: nm_update_routed_interface_port_ipv4_removed
+    
+    - name: Remove the ipv6_address from a L3out routed interface
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *update_routed_interface_port_channel_uuid
+        ipv6_address: ''
+      register: nm_update_routed_interface_port_ipv6_removed
+
+    - name: Remove the ipv6_link_local_address from a L3out routed interface
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *removed_ipv4_address
+        ipv6_link_local_address: ''
+      register: nm_update_routed_interface_port_ipv6_link_local_removed
+
+    - name: Assert that the ipv4_address, ipv6_address and ipv6_link_local_address were removed from the L3out routed interface
+      ansible.builtin.assert:
+        that:
+          - nm_update_routed_interface_port_ipv4_removed is changed
+          - nm_update_routed_interface_port_ipv4_removed.previous.addresses.primaryV4 == "10.0.0.2/24"
+          - nm_update_routed_interface_port_ipv4_removed.current.addresses.primaryV4 is not defined
+          - nm_update_routed_interface_port_ipv6_removed is changed
+          - nm_update_routed_interface_port_ipv6_removed.previous.addresses.primaryV6 == '1::112/16'
+          - nm_update_routed_interface_port_ipv6_removed.current.addresses.primaryV6 is not defined
+          - nm_update_routed_interface_port_ipv6_link_local_removed is changed
+          - nm_update_routed_interface_port_ipv6_link_local_removed.previous.addresses.linkLocalV6 == 'FE80::10'
+          - nm_update_routed_interface_port_ipv6_link_local_removed.current.addresses.linkLocalV6 is not defined
+
+    - name: Update a L3out routed interface of type port channel with micro bfd enabled
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface_port_channel_reference
+        port_channel:
+          micro_bfd_enabled: true
+          micro_bfd_address: 1::111
+          micro_bfd_start_timer: 70
+          reference:
+            name: '{{ port_channel_interface_2.current.name }}'
+            template: '{{ mso_fabric_resource_template | default("ansible_test") }}'
+      register: nm_update_routed_interface_port_channel_micro_bfd_enabled
+
+    - name: Update a L3out routed interface of type port channel with micro bfd disabled
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface_port_channel_reference
+        port_channel:
+          micro_bfd_enabled: false
+          reference:
+            name: '{{ port_channel_interface_2.current.name }}'
+            template: '{{ mso_fabric_resource_template | default("ansible_test") }}'
+      register: nm_update_routed_interface_port_channel_micro_bfd_to_false
+
+    - name: Assert that the L3out routed interface of type port channel with reference and micro bfd was created
+      ansible.builtin.assert:
+        that:
+          - nm_update_routed_interface_port_channel_micro_bfd_enabled is changed
+          - nm_update_routed_interface_port_channel_micro_bfd_enabled.previous.microBfd.address == "1::110"
+          - nm_update_routed_interface_port_channel_micro_bfd_enabled.previous.microBfd.startTimer == 60
+          - nm_update_routed_interface_port_channel_micro_bfd_enabled.current.microBfd.address == "1::111"
+          - nm_update_routed_interface_port_channel_micro_bfd_enabled.current.microBfd.startTimer == 70
+          - nm_update_routed_interface_port_channel_micro_bfd_to_false is changed
+          - nm_update_routed_interface_port_channel_micro_bfd_to_false.previous.microBfd.address == "1::111"
+          - nm_update_routed_interface_port_channel_micro_bfd_to_false.previous.microBfd.startTimer == 70
+          - nm_update_routed_interface_port_channel_micro_bfd_to_false.current.microBfd is not defined
+
+    - name: Update a L3out routed interface to use defined loopback as router id
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface_port_channel_reference
+        use_router_id_as_loopback: false
+        node_loopback_ip: 3.3.3.3
+      register: nm_update_routed_interface_port_channel_defined_loopback_as_router_id
+
+    - name: Update a L3out routed interface to use router id as loopback
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface_port_channel_reference
+      register: nm_update_routed_interface_port_channel_router_id_as_loopback
+
+    - name: Assert that the L3out routed interface of type port channel with router id as loopback was updated
+      ansible.builtin.assert:
+        that:
+          - nm_update_routed_interface_port_channel_defined_loopback_as_router_id is changed
+          - nm_update_routed_interface_port_channel_defined_loopback_as_router_id.previous.node.useRouteIDAsLoopback == true
+          - nm_update_routed_interface_port_channel_defined_loopback_as_router_id.previous.node.loopbackIPs is not defined
+          - nm_update_routed_interface_port_channel_defined_loopback_as_router_id.current.node.useRouteIDAsLoopback == false
+          - nm_update_routed_interface_port_channel_defined_loopback_as_router_id.current.node.loopbackIPs == ["3.3.3.3"]
+          - nm_update_routed_interface_port_channel_router_id_as_loopback is changed
+          - nm_update_routed_interface_port_channel_router_id_as_loopback.previous.node.useRouteIDAsLoopback == false
+          - nm_update_routed_interface_port_channel_router_id_as_loopback.previous.node.loopbackIPs == ["3.3.3.3"]
+          - nm_update_routed_interface_port_channel_router_id_as_loopback.current.node.useRouteIDAsLoopback == true
+          - nm_update_routed_interface_port_channel_router_id_as_loopback.current.node.loopbackIPs is not defined
+
+    # QUERY
+
+    - name: Get a L3out routed interface of type port
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface
+        state: query
+      register: query_routed_interface_port
+    
+    - name: Get a L3out routed interface of type port channel
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface_port_channel_uuid
+        state: query
+      register: query_routed_interface_port_channel
+    
+    - name: Query all L3out routed interfaces in a L3out
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *mso_info
+        template: '{{ mso_l3out_template | default("ansible_test") }}'
+        l3out: l3out_1
+        state: query
+      register: query_all_routed_interfaces
+
+    - name: Assert that the L3out routed interface of type port was queried
+      ansible.builtin.assert:
+        that:
+          - query_routed_interface_port is not changed
+          - query_routed_interface_port.current.podID == "1"
+          - query_routed_interface_port.current.nodeID == "101"
+          - query_routed_interface_port.current.path == "eth1/1"
+          - query_routed_interface_port.current.pathRef is not defined
+          - query_routed_interface_port.current.pathType == "port"
+          - query_routed_interface_port.current.templateId is defined
+          - query_routed_interface_port.current.templateName is defined
+          - query_routed_interface_port.current.mtu == "1000"
+          - query_routed_interface_port.current.mac == "00:22:BD:F8:19:FE"
+          - query_routed_interface_port.current.group == "interface_group_policy_1"
+          - query_routed_interface_port.current.targetDscp == "af11"
+          - query_routed_interface_port.current.addresses.primaryV4 is not defined
+          - query_routed_interface_port.current.addresses.primaryV6 == "2::101/16"
+          - query_routed_interface_port.current.addresses.linkLocalV6 is not defined
+          - query_routed_interface_port.current.addresses.ipV6DAD == "enabled"
+          - query_routed_interface_port.current.node.nodeID == "101"
+          - query_routed_interface_port.current.node.podID == "1"
+          - query_routed_interface_port.current.node.routerID == "1.1.1.1"
+          - query_routed_interface_port.current.node.useRouteIDAsLoopback == false
+          - query_routed_interface_port.current.node.loopbackIPs is not defined
+          - query_routed_interface_port.current.node.group == "node_group_policy_1"
+          - query_routed_interface_port_channel is not changed
+          - query_routed_interface_port_channel.current.podID is not defined
+          - query_routed_interface_port_channel.current.nodeID is not defined
+          - query_routed_interface_port_channel.current.path is not defined
+          - query_routed_interface_port_channel.current.pathRef is defined
+          - query_routed_interface_port_channel.current.pathType == "pc"
+          - query_routed_interface_port_channel.current.portChannelName == "ansible_port_channel_interface_1"
+          - query_routed_interface_port_channel.current.portChannelTemplateId is defined
+          - query_routed_interface_port_channel.current.portChannelTemplateName is defined
+          - query_routed_interface_port_channel.current.templateId is defined
+          - query_routed_interface_port_channel.current.templateName is defined
+          - query_routed_interface_port_channel.current.mtu == "1500"
+          - query_routed_interface_port_channel.current.mac == "00:22:BD:F8:19:EE"
+          - query_routed_interface_port_channel.current.group == "interface_group_policy_1"
+          - query_routed_interface_port_channel.current.targetDscp == "cs5"
+          - query_routed_interface_port_channel.current.microBfd is not defined
+          - query_routed_interface_port_channel.current.addresses.primaryV4 == "10.1.0.3/24"
+          - query_routed_interface_port_channel.current.addresses.primaryV6 is not defined
+          - query_routed_interface_port_channel.current.addresses.linkLocalV6 == "FE80::20"
+          - query_routed_interface_port_channel.current.addresses.ipV6DAD == "enabled"
+          - query_routed_interface_port_channel.current.node.nodeID == "101"
+          - query_routed_interface_port_channel.current.node.podID == "1"
+          - query_routed_interface_port_channel.current.node.routerID == "1.1.1.1"
+          - query_routed_interface_port_channel.current.node.useRouteIDAsLoopback == false
+          - query_routed_interface_port_channel.current.node.loopbackIPs is not defined
+          - query_routed_interface_port_channel.current.node.group == "node_group_policy_1"
+          - query_all_routed_interfaces is not changed
+          - query_all_routed_interfaces.current | length == 3
+          - query_all_routed_interfaces.current.0 == query_routed_interface_port.current
+          - query_all_routed_interfaces.current.1 == query_routed_interface_port_channel.current
+          - query_all_routed_interfaces.current.2.podID is not defined
+          - query_all_routed_interfaces.current.2.nodeID is not defined
+          - query_all_routed_interfaces.current.2.path is not defined
+          - query_all_routed_interfaces.current.2.pathRef is defined
+          - query_all_routed_interfaces.current.2.pathType == "pc"
+          - query_all_routed_interfaces.current.2.portChannelName == "ansible_port_channel_interface_2"
+          - query_all_routed_interfaces.current.2.portChannelTemplateId is defined
+          - query_all_routed_interfaces.current.2.portChannelTemplateName is defined
+          - query_all_routed_interfaces.current.2.templateId is defined
+          - query_all_routed_interfaces.current.2.templateName is defined
+          - query_all_routed_interfaces.current.2.mtu == "2000"
+          - query_all_routed_interfaces.current.2.mac == "00:22:BD:F8:19:EE"
+          - query_all_routed_interfaces.current.2.group == ""
+          - query_all_routed_interfaces.current.2.targetDscp == "unspecified"
+          - query_all_routed_interfaces.current.2.microBfd.address == "1::110"
+          - query_all_routed_interfaces.current.2.microBfd.startTimer == 60
+          - query_all_routed_interfaces.current.2.addresses.primaryV4 is not defined
+          - query_all_routed_interfaces.current.2.addresses.primaryV6 == "1::102/16"
+          - query_all_routed_interfaces.current.2.addresses.linkLocalV6 is not defined
+          - query_all_routed_interfaces.current.2.addresses.ipV6DAD == "enabled"
+          - query_all_routed_interfaces.current.2.node.nodeID == "102"
+          - query_all_routed_interfaces.current.2.node.podID == "1"
+          - query_all_routed_interfaces.current.2.node.routerID == "2.2.2.2"
+          - query_all_routed_interfaces.current.2.node.useRouteIDAsLoopback == true
+          - query_all_routed_interfaces.current.2.node.loopbackIPs is not defined
+          - query_all_routed_interfaces.current.2.node.group == ""
+
+    # DELETE
+    
+    - name: Delete a L3out routed interface of type port (check mode)
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface
+        state: absent
+      check_mode: true
+      register: cm_delete_routed_interface_port
+    
+    - name: Delete a L3out routed interface of type port
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface
+        state: absent
+      register: nm_delete_routed_interface_port
+    
+    - name: Delete a L3out routed interface of type port again
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface
+        state: absent
+      register: nm_delete_routed_interface_port_again
+    
+    - name: Assert that the L3out routed interface of type port was deleted
+      ansible.builtin.assert:
+        that:
+          - cm_delete_routed_interface_port is changed
+          - cm_delete_routed_interface_port.previous == query_routed_interface_port.current
+          - cm_delete_routed_interface_port.proposed == cm_delete_routed_interface_port.current == {}
+          - nm_delete_routed_interface_port is changed
+          - nm_delete_routed_interface_port.previous == query_routed_interface_port.current
+          - nm_delete_routed_interface_port.proposed == nm_delete_routed_interface_port.current == {}
+          - nm_delete_routed_interface_port_again is not changed
+          - nm_delete_routed_interface_port_again.previous == nm_delete_routed_interface_port_again.proposed == nm_delete_routed_interface_port_again.current == {}
+    
+    - name: Delete a L3out routed interface of type port channel (check mode)
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface_port_channel_uuid
+        state: absent
+      check_mode: true
+      register: cm_delete_routed_interface_port_channel_uuid
+    
+    - name: Delete a L3out routed interface of type port channel
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface_port_channel_uuid
+        state: absent
+      register: nm_delete_routed_interface_port_channel_uuid
+    
+    - name: Delete a L3out routed interface of type port channel again
+      cisco.mso.ndo_l3out_routed_interface:
+        <<: *create_routed_interface_port_channel_uuid
+        state: absent
+      register: nm_delete_routed_interface_port_channel_uuid_again
+    
+    - name: Assert that the L3out routed interface of type port channel was deleted
+      ansible.builtin.assert:
+        that:
+          - cm_delete_routed_interface_port_channel_uuid is changed
+          - cm_delete_routed_interface_port_channel_uuid.previous == query_routed_interface_port_channel.current
+          - cm_delete_routed_interface_port_channel_uuid.proposed == cm_delete_routed_interface_port_channel_uuid.current == {}
+          - nm_delete_routed_interface_port_channel_uuid is changed
+          - nm_delete_routed_interface_port_channel_uuid.previous == query_routed_interface_port_channel.current
+          - nm_delete_routed_interface_port_channel_uuid.proposed == nm_delete_routed_interface_port_channel_uuid.current == {}
+          - nm_delete_routed_interface_port_channel_uuid_again is not changed
+          - nm_delete_routed_interface_port_channel_uuid_again.previous == nm_delete_routed_interface_port_channel_uuid_again.proposed == nm_delete_routed_interface_port_channel_uuid_again.current == {}
+
+    # CLEANUP TEMPLATE
+  
+    - name: Remove l3out template
+      cisco.mso.ndo_template:
+        <<: *ndo_l3out_template_absent
+    
+    - name: Remove ansible_test schema template
+      cisco.mso.mso_schema_template:
+        <<: *mso_schema_template_absent
+
+    - name: Remove ansible_fabric_resource_template fabric_resource template
+      cisco.mso.ndo_template:
+        <<: *ndo_fabric_resource_template_absent
+        
+    - name: Remove ansible_fabric_policy_template fabric_policy template
+      cisco.mso.ndo_template:
+        <<: *ndo_fabric_policy_template_absent
+
+    - name: Remove tenant
+      cisco.mso.mso_tenant:
+        <<: *mso_tenant_present
+        state: absent


### PR DESCRIPTION
fixes DCNE-428

part of #627 