### PR TITLE
[ignore] fix setup for ndo_l3out_template module tests (DCNE-840)

### DIFF
--- a/tests/integration/targets/ndo_l3out_template/tasks/main.yml
+++ b/tests/integration/targets/ndo_l3out_template/tasks/main.yml
@@ -31,6 +31,24 @@
   when: version.current.version is version('4.2', '>')
   block:
     # Setup Part
+    - name: Ensure ansible_test site exist
+      cisco.mso.mso_site:
+        <<: *mso_info
+        site: '{{ mso_site | default("ansible_test") }}'
+        state: query
+      register: ansible_test_site
+
+    - name: Ensure ansible_test tenant exist
+      cisco.mso.mso_tenant:
+        <<: *mso_info
+        tenant: '{{ ansible_tenant | default("ansible_test") }}'
+        users:
+          - "{{ mso_username }}"
+        sites:
+          - '{{ mso_site | default("ansible_test") }}'
+        state: present
+      when: ansible_test_site.current.common.name == mso_site | default("ansible_test")
+
     - name: Ensure l3out template not exist
       cisco.mso.ndo_template: &ndo_l3out_template_absent
         <<: *mso_info
@@ -63,24 +81,6 @@
         tenant: '{{ ansible_tenant | default("ansible_test") }}'
         template: "Template1"
         state: absent
-
-    - name: Ensure ansible_test site exist
-      cisco.mso.mso_site:
-        <<: *mso_info
-        site: '{{ mso_site | default("ansible_test") }}'
-        state: query
-      register: ansible_test_site
-
-    - name: Ensure ansible_test tenant exist
-      cisco.mso.mso_tenant:
-        <<: *mso_info
-        tenant: '{{ ansible_tenant | default("ansible_test") }}'
-        users:
-          - "{{ mso_username }}"
-        sites:
-          - '{{ mso_site | default("ansible_test") }}'
-        state: present
-      when: ansible_test_site.current.common.name == 'ansible_test'
 
     # Schema Template Setup for the VRF
     - name: Add an ansible_test schema template


### PR DESCRIPTION
order of site and tenant setups checks is wrong when site has no sites/tenants configured, moved to top of test setup

```
PLAY RECAP *********************************************************************
ndo_3_2                    : ok=90   changed=32   unreachable=0    failed=0    skipped=2    rescued=0    ignored=6   
ndo_4_1                    : ok=90   changed=32   unreachable=0    failed=0    skipped=2    rescued=0    ignored=6   
ndo_4_2                    : ok=90   changed=33   unreachable=0    failed=0    skipped=2    rescued=0    ignored=6 

Name                                         Stmts   Miss Branch BrPart  Cover
------------------------------------------------------------------------------
plugins/modules/ndo_l3out_template.py          333      0    202      6    99%
------------------------------------------------------------------------------