### PR TITLE
[ignore] fix setup for ndo_l3out_annotation module tests (DCNE-841)

### DIFF
--- a/tests/integration/targets/ndo_l3out_annotation/tasks/main.yml
+++ b/tests/integration/targets/ndo_l3out_annotation/tasks/main.yml
@@ -31,6 +31,24 @@
   when: version.current.version is version('4.2', '>')
   block:
     # Setup Part
+    - name: Ensure ansible_test site exist
+      cisco.mso.mso_site:
+        <<: *mso_info
+        site: '{{ mso_site | default("ansible_test") }}'
+        state: query
+      register: ansible_test_site
+
+    - name: Ensure ansible_test tenant exist
+      cisco.mso.mso_tenant:
+        <<: *mso_info
+        tenant: '{{ ansible_tenant | default("ansible_test") }}'
+        users:
+          - "{{ mso_username }}"
+        sites:
+          - '{{ mso_site | default("ansible_test") }}'
+        state: present
+      when: ansible_test_site.current.common.name == mso_site | default("ansible_test")
+
     - name: Ensure l3out template not exist
       cisco.mso.ndo_template: &ndo_l3out_template_absent
         <<: *mso_info
@@ -48,24 +66,6 @@
         tenant: '{{ ansible_tenant | default("ansible_test") }}'
         template: "Template1"
         state: absent
-
-    - name: Ensure ansible_test site exist
-      cisco.mso.mso_site:
-        <<: *mso_info
-        site: '{{ mso_site | default("ansible_test") }}'
-        state: query
-      register: ansible_test_site
-
-    - name: Ensure ansible_test tenant exist
-      cisco.mso.mso_tenant:
-        <<: *mso_info
-        tenant: '{{ ansible_tenant | default("ansible_test") }}'
-        users:
-          - "{{ mso_username }}"
-        sites:
-          - '{{ mso_site | default("ansible_test") }}'
-        state: present
-      when: ansible_test_site.current.common.name == 'ansible_test'
 
     # Schema Template Setup for the VRF
     - name: Add an ansible_test schema template


### PR DESCRIPTION
order of site and tenant setups checks is wrong when site has no sites/tenants configured, moved to top of test setup


```
PLAY RECAP *********************************************************************
ndo_3_2                    : ok=50   changed=14   unreachable=0    failed=0    skipped=1    rescued=0    ignored=3   
ndo_4_1                    : ok=50   changed=14   unreachable=0    failed=0    skipped=1    rescued=0    ignored=3   
ndo_4_2                    : ok=50   changed=15   unreachable=0    failed=0    skipped=1    rescued=0    ignored=3 

Name                                         Stmts   Miss Branch BrPart  Cover
------------------------------------------------------------------------------
plugins/modules/ndo_l3out_annotation.py         61      0     24      1    99%
------------------------------------------------------------------------------