### PR TITLE
[minor_change] Add multiple node group policy support to ndo_l3out_routed_sub_interface (DCNE-847)

### DIFF
--- a/plugins/modules/ndo_l3out_routed_sub_interface.py
+++ b/plugins/modules/ndo_l3out_routed_sub_interface.py
@@ -64,7 +64,22 @@ options:
   node_group_policy:
     description:
     - The name of the node group policy.
+    - This parameter is supported on all versions and references a single node group policy.
+    - This parameter and O(node_group_policies) are mutually exclusive.
+    - To remove the node group policy, set this parameter to an empty string O(node_group_policy="").
+    - On ND v4.2 (NDO v5.2) and later the controller stores a single O(node_group_policy) under C(nodeGroups)
+      and clears C(group). This translation is reflected in the returned configuration after the change is applied,
+      but not in check mode, which returns the value under C(group). Use O(node_group_policies) for a representation
+      that matches in both check mode and normal mode.
     type: str
+  node_group_policies:
+    description:
+    - The names of the node group policies.
+    - This parameter is only supported on ND v4.2 (NDO v5.2) and later.
+    - This parameter and O(node_group_policy) are mutually exclusive.
+    - To remove all node group policies, set this parameter to an empty list O(node_group_policies=[]).
+    type: list
+    elements: str
   use_router_id_as_loopback:
     description:
     - Whether to use the router ID as the loopback address of the node.
@@ -201,7 +216,7 @@ notes:
   The M(cisco.mso.ndo_template) module can be used for this.
 - The O(l3out) or O(l3out_uuid) must exist before using this module in your playbook.
   The M(cisco.mso.ndo_l3out_template) module can be used for this.
-- The O(node_group_policy) must exist before using this module in your playbook.
+- The O(node_group_policy) or O(node_group_policies) must exist before using this module in your playbook.
   The M(cisco.mso.ndo_l3out_node_group_policy) module can be used for this.
 - The O(interface_group_policy) must exist before using this module in your playbook.
   The M(cisco.mso.ndo_l3out_interface_group_policy) module can be used for this.
@@ -308,6 +323,23 @@ EXAMPLES = r"""
     node_loopback_ip: 10.0.0.1
     state: present
 
+- name: Update a L3Out Routed Sub-Interface with multiple node group policies
+  cisco.mso.ndo_l3out_routed_sub_interface:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    template: l3out_template
+    l3out: l3out_name
+    node_id: 101
+    path: eth1/1
+    encapsulation_type: vlan
+    encapsulation_value: 100
+    node_router_id: 1.1.1.1
+    node_group_policies:
+      - node_group_policy_1
+      - node_group_policy_2
+    state: present
+
 - name: Remove PTP configuration from a L3Out Routed Sub-Interface of type port
   cisco.mso.ndo_l3out_routed_sub_interface:
     host: mso_host
@@ -396,6 +428,7 @@ def main():
         l3out_uuid=dict(type="str"),
         node_id=dict(type="str", aliases=["node", "border_leaf"]),
         node_group_policy=dict(type="str"),
+        node_group_policies=dict(type="list", elements="str"),
         node_router_id=dict(type="str", aliases=["router_id"]),
         use_router_id_as_loopback=dict(type="bool"),
         node_loopback_ip=dict(type="str", aliases=["loopback_ip"]),
@@ -435,6 +468,7 @@ def main():
             ["l3out", "l3out_uuid"],
             ["port_channel", "path"],
             ["port_channel", "node_id"],
+            ["node_group_policy", "node_group_policies"],
         ],
     )
 

--- a/tests/integration/targets/ndo_l3out_routed_sub_interface/tasks/main.yml
+++ b/tests/integration/targets/ndo_l3out_routed_sub_interface/tasks/main.yml
@@ -220,13 +220,16 @@
           state: enabled
         state: present
 
-    - name: Create L3Out node group policy
+    - name: Create L3Out node group policies
       cisco.mso.ndo_l3out_node_group_policy:
         <<: *mso_info
         template: '{{ mso_l3out_template | default("ansible_test") }}'
         l3out: l3out_1
-        name: node_group_policy_1
+        name: '{{ item }}'
         state: present
+      loop:
+        - node_group_policy_1
+        - node_group_policy_2
 
     - name: Create L3Out interface group policy
       cisco.mso.ndo_l3out_interface_group_policy:
@@ -552,9 +555,32 @@
           - nm_update_routed_sub_interface_port is changed
           - nm_update_routed_sub_interface_port.previous == nm_create_routed_sub_interface_again.current
           - nm_update_routed_sub_interface_port.previous != nm_update_routed_sub_interface_port.current
-          - nm_update_routed_sub_interface_port.proposed == nm_update_routed_sub_interface_port.current == cm_update_routed_sub_interface_port.current
+          # The proposed/current comparison is version specific: from ND 4.2 onwards a single node_group_policy
+          # is returned under "nodeGroups" while "group" is cleared, so proposed (which sets "group") no longer
+          # matches current. It is therefore only asserted in the "< 5.2" block below where "group" is still used.
+          # - nm_update_routed_sub_interface_port.proposed == nm_update_routed_sub_interface_port.current == cm_update_routed_sub_interface_port.current
           - nm_update_routed_sub_interface_port_again is not changed
-          - nm_update_routed_sub_interface_port_again.previous == nm_update_routed_sub_interface_port_again.proposed == nm_update_routed_sub_interface_port_again.current == nm_update_routed_sub_interface_port.current
+          - nm_update_routed_sub_interface_port_again.previous == nm_update_routed_sub_interface_port_again.current == nm_update_routed_sub_interface_port.current
+
+    - name: Assert that the L3out routed sub-interface of type port was updated (>= 5.2)
+      ansible.builtin.assert:
+        that:
+          - nm_update_routed_sub_interface_port.current.node.group == ""
+          - nm_update_routed_sub_interface_port.current.node.nodeGroups == ["node_group_policy_1"]
+          - nm_update_routed_sub_interface_port_again.current.node.group == ""
+          - nm_update_routed_sub_interface_port_again.current.node.nodeGroups == ["node_group_policy_1"]
+      when: version.current.version is version('5.2', '>=')
+
+    - name: Assert that the L3out routed sub-interface of type port was updated (< 5.2)
+      ansible.builtin.assert:
+        that:
+          - nm_update_routed_sub_interface_port.current.node.group == "node_group_policy_1"
+          - nm_update_routed_sub_interface_port.current.node.nodeGroups is not defined
+          - nm_update_routed_sub_interface_port.proposed == nm_update_routed_sub_interface_port.current == cm_update_routed_sub_interface_port.current
+          - nm_update_routed_sub_interface_port_again.current.node.group == "node_group_policy_1"
+          - nm_update_routed_sub_interface_port_again.current.node.nodeGroups is not defined
+          - nm_update_routed_sub_interface_port_again.previous == nm_update_routed_sub_interface_port_again.proposed == nm_update_routed_sub_interface_port_again.current
+      when: version.current.version is version('5.2', '<')
 
     - name: Update a L3out routed sub-interface of type port channel with uuid (check mode)
       cisco.mso.ndo_l3out_routed_sub_interface: &update_routed_sub_interface_port_channel_uuid
@@ -612,7 +638,6 @@
           - cm_update_routed_sub_interface_port_channel_uuid.current.node.routerID == "1.1.1.1"
           - cm_update_routed_sub_interface_port_channel_uuid.current.node.useRouteIDAsLoopback == false
           - cm_update_routed_sub_interface_port_channel_uuid.current.node.loopbackIPs is not defined
-          - cm_update_routed_sub_interface_port_channel_uuid.current.node.group == "node_group_policy_1"
           - cm_update_routed_sub_interface_port_channel_uuid.current.nodeID is not defined
           - cm_update_routed_sub_interface_port_channel_uuid.current.path is not defined
           - cm_update_routed_sub_interface_port_channel_uuid.current.pathRef is defined
@@ -637,9 +662,33 @@
           - nm_update_routed_sub_interface_port_channel_uuid is changed
           - nm_update_routed_sub_interface_port_channel_uuid.previous != nm_create_routed_sub_interface_port_channel_uuid_again.current
           - nm_update_routed_sub_interface_port_channel_uuid.previous != nm_update_routed_sub_interface_port_channel_uuid.current
-          - nm_update_routed_sub_interface_port_channel_uuid.proposed == nm_update_routed_sub_interface_port_channel_uuid.current == cm_update_routed_sub_interface_port_channel_uuid.current
+          # The proposed/current comparison is version specific: from ND 4.2 onwards a single node_group_policy
+          # is returned under "nodeGroups" while "group" is cleared, so proposed (which sets "group") no longer
+          # matches current. It is therefore only asserted in the "< 5.2" block below where "group" is still used.
+          # - nm_update_routed_sub_interface_port_channel_uuid.proposed == nm_update_routed_sub_interface_port_channel_uuid.current == cm_update_routed_sub_interface_port_channel_uuid.current
           - nm_update_routed_sub_interface_port_channel_uuid_again is not changed
-          - nm_update_routed_sub_interface_port_channel_uuid_again.previous == nm_update_routed_sub_interface_port_channel_uuid_again.proposed == nm_update_routed_sub_interface_port_channel_uuid_again.current == nm_update_routed_sub_interface_port_channel_uuid.current
+          - nm_update_routed_sub_interface_port_channel_uuid_again.previous == nm_update_routed_sub_interface_port_channel_uuid_again.current == nm_update_routed_sub_interface_port_channel_uuid.current
+
+    - name: Assert that the L3out routed sub-interface of type port channel was updated (>= 5.2)
+      ansible.builtin.assert:
+        that:
+          - nm_update_routed_sub_interface_port_channel_uuid.current.node.group == ""
+          - nm_update_routed_sub_interface_port_channel_uuid.current.node.nodeGroups == ["node_group_policy_1"]
+          - nm_update_routed_sub_interface_port_channel_uuid_again.current.node.group == ""
+          - nm_update_routed_sub_interface_port_channel_uuid_again.current.node.nodeGroups == ["node_group_policy_1"]
+      when: version.current.version is version('5.2', '>=')
+
+    - name: Assert that the L3out routed sub-interface of type port channel was updated (< 5.2)
+      ansible.builtin.assert:
+        that:
+          - cm_update_routed_sub_interface_port_channel_uuid.current.node.group == "node_group_policy_1"
+          - nm_update_routed_sub_interface_port_channel_uuid.current.node.group == "node_group_policy_1"
+          - nm_update_routed_sub_interface_port_channel_uuid.current.node.nodeGroups is not defined
+          - nm_update_routed_sub_interface_port_channel_uuid.proposed == nm_update_routed_sub_interface_port_channel_uuid.current == cm_update_routed_sub_interface_port_channel_uuid.current
+          - nm_update_routed_sub_interface_port_channel_uuid_again.current.node.group == "node_group_policy_1"
+          - nm_update_routed_sub_interface_port_channel_uuid_again.current.node.nodeGroups is not defined
+          - nm_update_routed_sub_interface_port_channel_uuid_again.previous == nm_update_routed_sub_interface_port_channel_uuid_again.proposed == nm_update_routed_sub_interface_port_channel_uuid_again.current
+      when: version.current.version is version('5.2', '<')
 
     - name: Remove destination IPs from PTP configuration
       cisco.mso.ndo_l3out_routed_sub_interface: &remove_ptp_dest_ips
@@ -758,6 +807,47 @@
           - nm_update_routed_sub_interface_port_channel_router_id_as_loopback.previous.node.loopbackIPs == ["3.3.3.3"]
           - nm_update_routed_sub_interface_port_channel_router_id_as_loopback.current.node.useRouteIDAsLoopback == true
           - nm_update_routed_sub_interface_port_channel_router_id_as_loopback.current.node.loopbackIPs is not defined
+
+    - name: Update a L3out routed sub-interface with multiple node_group_policies (check mode) (>= 5.2)
+      cisco.mso.ndo_l3out_routed_sub_interface: &update_routed_sub_interface_multiple_node_group_policies
+        <<: *update_routed_sub_interface_port_channel_uuid
+        node_group_policy: "{{ omit }}"
+        node_group_policies:
+          - node_group_policy_1
+          - node_group_policy_2
+      check_mode: true
+      register: cm_update_routed_sub_interface_multiple_node_group_policies
+      when: version.current.version is version('5.2', '>=')
+
+    - name: Update a L3out routed sub-interface with multiple node_group_policies (>= 5.2)
+      cisco.mso.ndo_l3out_routed_sub_interface:
+        <<: *update_routed_sub_interface_multiple_node_group_policies
+      register: nm_update_routed_sub_interface_multiple_node_group_policies
+      when: version.current.version is version('5.2', '>=')
+
+    - name: Update a L3out routed sub-interface with multiple node_group_policies again (>= 5.2)
+      cisco.mso.ndo_l3out_routed_sub_interface:
+        <<: *update_routed_sub_interface_multiple_node_group_policies
+      register: nm_update_routed_sub_interface_multiple_node_group_policies_again
+      when: version.current.version is version('5.2', '>=')
+
+    - name: Assert that the L3out routed sub-interface with multiple node_group_policies was updated (>= 5.2)
+      ansible.builtin.assert:
+        that:
+          - cm_update_routed_sub_interface_multiple_node_group_policies is changed
+          - cm_update_routed_sub_interface_multiple_node_group_policies.proposed.node.group == ""
+          - cm_update_routed_sub_interface_multiple_node_group_policies.proposed.node.nodeGroups == ["node_group_policy_1", "node_group_policy_2"]
+          - nm_update_routed_sub_interface_multiple_node_group_policies is changed
+          - nm_update_routed_sub_interface_multiple_node_group_policies.previous.node.group == ""
+          - nm_update_routed_sub_interface_multiple_node_group_policies.previous.node.nodeGroups == ["node_group_policy_1"]
+          - nm_update_routed_sub_interface_multiple_node_group_policies.current.node.group == ""
+          - nm_update_routed_sub_interface_multiple_node_group_policies.current.node.nodeGroups == ["node_group_policy_1", "node_group_policy_2"]
+          # Unlike a single node_group_policy, node_group_policies is sent under "nodeGroups" and is not translated by
+          # the API, so the check mode current node matches the normal mode current.
+          - nm_update_routed_sub_interface_multiple_node_group_policies.current == cm_update_routed_sub_interface_multiple_node_group_policies.current
+          - nm_update_routed_sub_interface_multiple_node_group_policies_again is not changed
+          - nm_update_routed_sub_interface_multiple_node_group_policies_again.previous == nm_update_routed_sub_interface_multiple_node_group_policies_again.current == cm_update_routed_sub_interface_multiple_node_group_policies.current
+      when: version.current.version is version('5.2', '>=')
 
     # ERROR HANDLING
 
@@ -884,6 +974,22 @@
           - error_create_routed_sub_interface_port_channel_invalid_user_profile_with_both_templates is failed
           - 'error_create_routed_sub_interface_port_channel_invalid_user_profile_with_both_templates.msg == "parameters are mutually exclusive: template|template_id found in ptp -> user_profile -> reference"'
 
+    - name: Create a L3out routed sub-interface with node_group_policy and node_group_policies
+      cisco.mso.ndo_l3out_routed_sub_interface:
+        <<: *update_routed_sub_interface_port_channel_uuid
+        node_group_policy: node_group_policy_1
+        node_group_policies:
+          - node_group_policy_1
+          - node_group_policy_2
+      register: error_routed_sub_interface_node_group_policy_and_policies
+      ignore_errors: true
+
+    - name: Assert that the mutually exclusive node_group_policy and node_group_policies error was raised
+      ansible.builtin.assert:
+        that:
+          - error_routed_sub_interface_node_group_policy_and_policies is failed
+          - 'error_routed_sub_interface_node_group_policy_and_policies.msg == "parameters are mutually exclusive: node_group_policy|node_group_policies"'
+
     # QUERY
 
     - name: Get a L3out routed sub-interface of type port
@@ -930,7 +1036,6 @@
           - query_routed_sub_interface_port.current.node.routerID == "1.1.1.1"
           - query_routed_sub_interface_port.current.node.useRouteIDAsLoopback == false
           - query_routed_sub_interface_port.current.node.loopbackIPs is not defined
-          - query_routed_sub_interface_port.current.node.group == "node_group_policy_1"
           - query_routed_sub_interface_port_channel is not changed
           - query_routed_sub_interface_port_channel.current.podID is not defined
           - query_routed_sub_interface_port_channel.current.nodeID is not defined
@@ -947,7 +1052,6 @@
           - query_routed_sub_interface_port_channel.current.group == "interface_group_policy_1"
           - query_routed_sub_interface_port_channel.current.targetDscp == "cs5"
           - query_routed_sub_interface_port_channel.current.addresses.primaryV4 == "10.1.0.3/24"
-          - query_routed_sub_interface_port_channel.current.addresses.primaryV6 is not defined
           - query_routed_sub_interface_port_channel.current.addresses.linkLocalV6 == "FE80::20"
           - query_routed_sub_interface_port_channel.current.addresses.ipV6DAD == "enabled"
           - query_routed_sub_interface_port_channel.current.node.nodeID == "101"
@@ -955,7 +1059,6 @@
           - query_routed_sub_interface_port_channel.current.node.routerID == "1.1.1.1"
           - query_routed_sub_interface_port_channel.current.node.useRouteIDAsLoopback == false
           - query_routed_sub_interface_port_channel.current.node.loopbackIPs is not defined
-          - query_routed_sub_interface_port_channel.current.node.group == "node_group_policy_1"
           - query_all_routed_sub_interfaces is not changed
           - query_all_routed_sub_interfaces.current | length == 3
           - query_all_routed_sub_interfaces.current.0 == query_routed_sub_interface_port.current
@@ -984,6 +1087,30 @@
           - query_all_routed_sub_interfaces.current.2.node.useRouteIDAsLoopback == true
           - query_all_routed_sub_interfaces.current.2.node.loopbackIPs is not defined
           - query_all_routed_sub_interfaces.current.2.node.group == ""
+
+    - name: Assert that the L3out routed sub-interfaces were queried (>= 5.2)
+      ansible.builtin.assert:
+        that:
+          - query_routed_sub_interface_port.current.node.group == ""
+          # Node 101 hosts both the port and port_channel sub-interfaces; the multi node_group_policies update
+          # on the port_channel sets node 101 nodeGroups to both policies, so the port query reflects the same.
+          - query_routed_sub_interface_port.current.node.nodeGroups == ["node_group_policy_1", "node_group_policy_2"]
+          - query_routed_sub_interface_port_channel.current.node.group == ""
+          - query_routed_sub_interface_port_channel.current.node.nodeGroups == ["node_group_policy_1", "node_group_policy_2"]
+          # The multi node_group_policies update block re-applies the original ipv6_address from the
+          # update_routed_sub_interface_port_channel_uuid anchor, so primaryV6 is restored on >= 5.2.
+          - query_routed_sub_interface_port_channel.current.addresses.primaryV6 == "1::112/16"
+      when: version.current.version is version('5.2', '>=')
+
+    - name: Assert that the L3out routed sub-interfaces were queried (< 5.2)
+      ansible.builtin.assert:
+        that:
+          - query_routed_sub_interface_port.current.node.group == "node_group_policy_1"
+          - query_routed_sub_interface_port.current.node.nodeGroups is not defined
+          - query_routed_sub_interface_port_channel.current.node.group == "node_group_policy_1"
+          - query_routed_sub_interface_port_channel.current.node.nodeGroups is not defined
+          - query_routed_sub_interface_port_channel.current.addresses.primaryV6 is not defined
+      when: version.current.version is version('5.2', '<')
 
     # DELETE
 


### PR DESCRIPTION
fixes DCNE-847

```
PLAY RECAP *********************************************************************
ndo_3_2                    : ok=90   changed=40   unreachable=0    failed=0    skipped=8    rescued=0    ignored=11  
ndo_4_1                    : ok=90   changed=40   unreachable=0    failed=0    skipped=8    rescued=0    ignored=11  
ndo_4_2                    : ok=94   changed=43   unreachable=0    failed=0    skipped=4    rescued=0    ignored=11  

Name                                                  Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------------------------------
plugins/modules/ndo_l3out_routed_sub_interface.py       135      0     50      1    99%
