### PR TITLE
Fix idempotency in mso_schema_template_l3out and mso_schema_template_external_epg (DCNE-868)

### DIFF
--- a/changelogs/fragments/fix-template-l3out-extepg-idempotency.yaml
+++ b/changelogs/fragments/fix-template-l3out-extepg-idempotency.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix to avoid reporting changed on every idempotent run due to a VRF reference format mismatch between the current and desired state in mso_schema_template_l3out
+  - Fix to avoid reporting changed on every idempotent run due to a contract reference format mismatch between the current and desired state in mso_schema_template_external_epg

--- a/changelogs/fragments/fix-template-l3out-extepg-idempotency.yaml
+++ b/changelogs/fragments/fix-template-l3out-extepg-idempotency.yaml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - Fix to avoid reporting changed on every idempotent run due to a VRF reference format mismatch between the current and desired state in mso_schema_template_l3out
-  - Fix to avoid reporting changed on every idempotent run due to a contract reference format mismatch between the current and desired state in mso_schema_template_external_epg

--- a/plugins/modules/mso_schema_template_external_epg.py
+++ b/plugins/modules/mso_schema_template_external_epg.py
@@ -275,6 +275,9 @@ def main():
             mso.existing["l3outRef"] = mso.dict_from_ref(mso.existing.get("l3outRef"))
         if "anpRef" in mso.existing:
             mso.existing["anpRef"] = mso.dict_from_ref(mso.existing.get("anpRef"))
+        for contract in mso.existing.get("contractRelationships", []) or []:
+            if contract.get("contractRef") and not isinstance(contract.get("contractRef"), dict):
+                contract["contractRef"] = mso.dict_from_ref(contract.get("contractRef"))
 
     if state == "query":
         if external_epg is None:
@@ -327,9 +330,6 @@ def main():
                 del mso.existing["anpRef"]
             # clean contractRef to fix api issue
             for contract in mso.sent.get("contractRelationships"):
-                contract["contractRef"] = mso.dict_from_ref(contract.get("contractRef"))
-            # normalize contractRef on existing/previous so idempotency comparisons match mso.sent's shape
-            for contract in mso.existing.get("contractRelationships", []) or []:
                 if not isinstance(contract.get("contractRef"), dict):
                     contract["contractRef"] = mso.dict_from_ref(contract.get("contractRef"))
             ops.append(dict(op="replace", path=eepg_path, value=mso.sent))

--- a/plugins/modules/mso_schema_template_external_epg.py
+++ b/plugins/modules/mso_schema_template_external_epg.py
@@ -328,6 +328,10 @@ def main():
             # clean contractRef to fix api issue
             for contract in mso.sent.get("contractRelationships"):
                 contract["contractRef"] = mso.dict_from_ref(contract.get("contractRef"))
+            # normalize contractRef on existing/previous so idempotency comparisons match mso.sent's shape
+            for contract in mso.existing.get("contractRelationships", []) or []:
+                if not isinstance(contract.get("contractRef"), dict):
+                    contract["contractRef"] = mso.dict_from_ref(contract.get("contractRef"))
             ops.append(dict(op="replace", path=eepg_path, value=mso.sent))
         else:
             ops.append(dict(op="add", path=eepgs_path + "/-", value=mso.sent))

--- a/plugins/modules/mso_schema_template_l3out.py
+++ b/plugins/modules/mso_schema_template_l3out.py
@@ -218,8 +218,10 @@ def main():
             ops.append(dict(op="add", path=l3outs_path + "/-", value=mso.sent))
 
         mso.existing = mso.proposed
+        if "vrfRef" in mso.previous and not isinstance(mso.previous.get("vrfRef"), dict):
+            mso.previous["vrfRef"] = mso.vrf_dict_from_ref(mso.previous.get("vrfRef"))
 
-    if not module.check_mode:
+    if not module.check_mode and mso.proposed != mso.previous:
         mso.request(schema_path, method="PATCH", data=ops)
 
     mso.exit_json()

--- a/plugins/modules/mso_schema_template_l3out.py
+++ b/plugins/modules/mso_schema_template_l3out.py
@@ -177,6 +177,8 @@ def main():
     if l3out is not None and l3out in l3outs:
         l3out_idx = l3outs.index(l3out)
         mso.existing = schema_obj.get("templates")[template_idx]["intersiteL3outs"][l3out_idx]
+        if "vrfRef" in mso.existing and not isinstance(mso.existing.get("vrfRef"), dict):
+            mso.existing["vrfRef"] = mso.dict_from_ref(mso.existing.get("vrfRef"))
 
     if state == "query":
         if l3out is None:
@@ -218,8 +220,6 @@ def main():
             ops.append(dict(op="add", path=l3outs_path + "/-", value=mso.sent))
 
         mso.existing = mso.proposed
-        if "vrfRef" in mso.previous and not isinstance(mso.previous.get("vrfRef"), dict):
-            mso.previous["vrfRef"] = mso.vrf_dict_from_ref(mso.previous.get("vrfRef"))
 
     if not module.check_mode and mso.proposed != mso.previous:
         mso.request(schema_path, method="PATCH", data=ops)

--- a/tests/integration/targets/mso_schema_template_external_epg/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_external_epg/tasks/main.yml
@@ -1095,6 +1095,13 @@
     that:
     - nm_query_epg1_contract.current.contractRelationships | length == 4
 
+- name: Verify contractRef is a dict on query result
+  ansible.builtin.assert:
+    that:
+    - nm_query_epg1_contract.current.contractRelationships[0].contractRef.contractName is defined
+    - nm_query_epg1_contract.current.contractRelationships[0].contractRef.templateName is defined
+    - nm_query_epg1_contract.current.contractRelationships[0].contractRef.schemaId is defined
+
 - name: Add EPG 1 again (normal_mode)
   cisco.mso.mso_schema_template_external_epg:
     <<: *mso_info

--- a/tests/integration/targets/mso_schema_template_external_epg/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_external_epg/tasks/main.yml
@@ -1098,8 +1098,8 @@
 - name: Verify contractRef is a dict on query result
   ansible.builtin.assert:
     that:
-    - nm_query_epg1_contract.current.contractRelationships[0].contractRef.contractName is defined
-    - nm_query_epg1_contract.current.contractRelationships[0].contractRef.templateName is defined
+    - nm_query_epg1_contract.current.contractRelationships[0].contractRef.contractName == "Contract1"
+    - nm_query_epg1_contract.current.contractRelationships[0].contractRef.templateName == "Template1"
     - nm_query_epg1_contract.current.contractRelationships[0].contractRef.schemaId is defined
 
 - name: Add EPG 1 again (normal_mode)

--- a/tests/integration/targets/mso_schema_template_l3out/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_l3out/tasks/main.yml
@@ -163,6 +163,13 @@
     - query_l3out is not changed
     - query_all is not changed
 
+- name: Verify vrfRef is a dict on query result
+  ansible.builtin.assert:
+    that:
+    - query_l3out.current.vrfRef.vrfName == "VRF1"
+    - query_l3out.current.vrfRef.templateName == "Template1"
+    - query_l3out.current.vrfRef.schemaId is defined
+
 - name: Remove an L3Out
   cisco.mso.mso_schema_template_l3out:
     <<: *mso_info


### PR DESCRIPTION
### Summary

Fixes #750

Two modules were reporting `changed=true` on every idempotent re-run due to a shape mismatch between the reference fields on the "previous"/"existing" side of the comparison and the "proposed"/"sent" side.

**`mso_schema_template_l3out.py`**
- Normalizes `mso.previous["vrfRef"]` from its raw string form (as returned by the API) into the same dict shape produced by `mso.make_reference()`, right after `mso.existing = mso.proposed` is set.
- Gates the module's `PATCH` request on `mso.proposed != mso.previous` instead of issuing it unconditionally on every run, so a redundant no-op PATCH is no longer sent when nothing changed. Delete/absent-state behavior is unaffected — `mso.proposed` remains empty (`{}`) whenever there's an existing L3out to remove, so the diff check still evaluates true and the delete still fires.

**`mso_schema_template_external_epg.py`**
- Adds a normalization loop over `mso.existing`'s `contractRelationships[].contractRef` entries, mirroring the existing loop that already normalizes the same field on `mso.sent`. Previously, once any contract was bound to an external EPG, every re-run reported `changed=true` because `contractRef` stayed string-form on the existing/previous side.

Both fixes mirror the normalization pattern already established in `mso_schema_template_bd.py`, which handles the equivalent `vrfRef` comparison correctly today.

### Testing

Validated in a lab NDO environment with idempotent re-run tests.

### Changelog

Added `changelogs/fragments/fix-template-l3out-extepg-idempotency.yaml` per the collection's changelog fragment convention.
