### PR TITLE
Add tests for mso schema template anp epg subnet (DCNE-894)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -327,6 +327,11 @@ visible until the module is corrected.
     description: Updated parent
   register: nm_update_parent
 
+- name: Update parent without managing the child object again
+  cisco.mso.<parent_module>:
+    <<: *parent_updated
+  register: nm_update_parent_again
+
 - name: Query child after parent update
   cisco.mso.<child_module>:
     <<: *child_query

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,514 @@
+# Development Guide
+
+This guide defines the expected structure for integration tests in the
+`cisco.mso` collection. Use it when adding tests for a new module or cleaning
+up an existing target.
+
+## Module creation
+
+TODO: document the standard process for creating a module, including argument
+specification, module documentation, examples, idempotency, version support,
+and the corresponding integration-test target.
+
+## Integration-test targets
+
+Each module test is stored in
+`tests/integration/targets/<module_name>/tasks/main.yml`. Add an `aliases` file
+for every integration-test target. The `unsupported` entry is an
+`ansible-test` marker for the test target; it does not describe the module's
+support status. Keep the marker commented while the target is supported:
+
+```text
+# The module and integration test are supported.
+# Uncomment the following line to exclude this test target when necessary.
+# unsupported
+```
+
+When the target is not currently runnable, activate the marker and document the
+reason:
+
+```text
+# The module is supported, but this integration test is not currently run
+# because <required environment or feature> is unavailable.
+unsupported
+```
+
+Keep test-specific exceptions documented next to the affected target.
+
+## Test setup
+
+Validate the connection variables and define shared connection data and test
+fixtures once at the top of the test. Use target-specific variables first,
+generic variables second, and a static default last. For example:
+
+```yaml
+- name: Test that required variables are defined
+  ansible.builtin.fail:
+    msg: 'Please define mso_hostname, mso_username and mso_password.'
+  when: >-
+    mso_hostname is not defined or
+    mso_username is not defined or
+    mso_password is not defined
+
+- name: Set test connection and fixture variables
+  ansible.builtin.set_fact:
+    mso_info: &mso_info
+      host: '{{ mso_hostname }}'
+      username: '{{ mso_username }}'
+      password: '{{ mso_password }}'
+      validate_certs: '{{ mso_validate_certs | default(false) }}'
+      use_ssl: '{{ mso_use_ssl | default(true) }}'
+      use_proxy: '{{ mso_use_proxy | default(true) }}'
+      output_level: debug
+    mso_test:
+      schema: '{{ mso_schema_example | default(mso_schema | default("ansible_test")) }}'
+      template: Template1
+      attribute_name: attribute_value
+```
+
+Replace `example` with the target-specific variable name. Keep the specific
+override, generic override, and static default when all three levels are
+needed by the target.
+
+## Version-specific behavior
+
+Query the controller version once when the test contains version-dependent
+behavior. Use a version-gated block when the complete test applies only to a
+specific controller version; this allows the condition to bypass the entire
+test, including its clean-environment tasks. Keep the test lifecycle in an
+`Exercise <module_name>` block with an `always` section so cleanup runs when
+that exercise starts and later fails. Use a task-level condition for an
+individual feature within the version-gated block:
+
+```yaml
+- name: Query controller version
+  cisco.mso.mso_version:
+    <<: *mso_info
+    state: query
+  register: version
+
+- name: Run tests supported from ND v4.1 (NDO v5.1)
+  when: version.current.version is version('5.1', '>=')
+  block:
+    - name: Exercise <module_name>
+      block:
+        # CLEAN ENVIRONMENT
+        - name: Remove the version-dependent test object before testing
+          cisco.mso.<module_name>:
+            <<: *mso_info
+            name: versioned_object_name
+            state: absent
+
+        - name: Test feature supported from ND v4.2 (NDO v5.2)
+          cisco.mso.<module_name>:
+            <<: *mso_info
+            name: versioned_object_name
+          when: version.current.version is version('5.2', '>=')
+
+      always:
+        # CLEANUP
+```
+
+Use a version condition only around functionality that is genuinely
+unsupported on that version. A version exclusion may bypass the complete
+version-gated exercise, but must not hide unrelated setup, assertions, or
+cleanup for tests that are otherwise supported. Explain the version-specific
+behavior in a comment or task name, using both product versions where relevant.
+
+## Pre-existing objects
+
+Some tests require objects that must already exist in the test environment. Do
+not create or query those objects as part of the target when the API or test
+contract makes them prerequisites. State the reason in a comment, for example:
+
+```yaml
+# Due to API changes in ND 4.2, the configured site and tenant are prerequisites
+# for this test and must already exist. They are intentionally not created or
+# queried here.
+- name: Associate the pre-existing site with the test schema template
+  cisco.mso.mso_schema_site:
+    <<: *mso_info
+    schema: '{{ mso_test.schema }}'
+    site: '{{ mso_test.site }}'
+    template: '{{ mso_test.template }}'
+```
+
+The example uses the existing site without attempting to manage the site or
+tenant themselves.
+
+## Test block and cleanup
+
+Put the test lifecycle in an enclosing `block`. When version-dependent
+behavior is present, query the controller version before the version-gated
+block, as shown in [Version-specific behavior](#version-specific-behavior).
+The version-gated block may skip the complete exercise, including its
+clean-environment tasks. The clean-environment setup should be the first task
+in the `Exercise <module_name>` block. Keep cleanup in that block's `always`
+section so it runs when the exercise starts and later fails. If the surrounding
+version-gated block is skipped, the exercise and its cleanup are not run:
+
+```yaml
+- name: Exercise <module_name>
+  block:
+    # CLEAN ENVIRONMENT
+    - name: Remove the test object before testing
+      cisco.mso.<module_name>:
+        <<: *mso_info
+        name: '{{ mso_test.name }}'
+        state: absent
+
+    # CREATE, UPDATE, QUERY, DELETE, and ERROR HANDLING sections follow here.
+
+  always:
+    # CLEANUP
+    - name: Remove the test object even when a test fails
+      cisco.mso.<module_name>:
+        <<: *mso_info
+        name: '{{ mso_test.name }}'
+        state: absent
+```
+
+## General test conventions
+
+Apply these conventions to all integration-test tasks unless the module's
+documented behavior requires an exception:
+
+- Use descriptive task and fixture names that explain the scenario, such as
+  `Create subnet 1 with defaults`.
+- Use documented module defaults instead of repeating default values in
+  ordinary tasks. For example, when `state: present` is the module default,
+  omit it from ordinary setup and create tasks. Specify a default explicitly
+  only when testing required arguments or another state-dependent behavior.
+- When a module or ND defines a default, include a scenario that omits the
+  attribute and assert the effective value returned by the module. Module
+  defaults can be asserted in check mode and after the normal operation. ND
+  defaults should be verified after the normal operation or a subsequent
+  query, because the controller applies them.
+- Exercise every supported operation of the module under test in check mode,
+  including query and query-all operations when supported, and assert the
+  expected result. Supporting fixture creation tasks do not need separate
+  check-mode coverage when the same operation is already covered by a
+  lifecycle scenario.
+- Verify idempotency for mutating operations by repeating the operation and
+  asserting that the repeated task is not changed. The initial lifecycle task
+  provides check-mode coverage; do not repeat the idempotency task in check
+  mode unless check mode has distinct behavior that needs separate coverage.
+- Assert all relevant returned attributes for every applicable result, not only
+  the result of the initial create operation. Assert empty results after
+  deletion where the module provides them.
+- Add separate scenarios only when they cover a meaningful input or behavior
+  variation. Avoid duplicate scenarios that do not increase coverage.
+- Create only the prerequisites needed by the lifecycle under test. Do not
+  attempt to manage objects that are documented as pre-existing prerequisites;
+  document those requirements in the test as described in [Pre-existing
+  objects](#pre-existing-objects).
+
+## Create
+
+For each supported creation scenario, test check mode, the normal operation,
+and idempotency. Assert every relevant attribute, including module- or
+ND-defined defaults:
+
+The initial create result may contain only the payload produced by the module,
+while a repeated create or later query may include additional
+controller-generated attributes. Assert the managed attributes individually
+when comparing create and idempotency results so these different response
+shapes do not cause a false failure.
+
+```yaml
+- name: Create object in check mode
+  cisco.mso.<module_name>: &object_present
+    <<: *mso_info
+    name: '{{ mso_test.name }}'
+    description: Initial object
+  check_mode: true
+  register: cm_create_object
+
+- name: Create object
+  cisco.mso.<module_name>:
+    <<: *object_present
+  register: nm_create_object
+
+- name: Create object again
+  cisco.mso.<module_name>:
+    <<: *object_present
+  register: nm_create_object_again
+
+- name: Verify create and idempotency
+  ansible.builtin.assert:
+    that:
+      - cm_create_object is changed
+      - nm_create_object is changed
+      - nm_create_object_again is not changed
+      - cm_create_object.current.name == nm_create_object.current.name == mso_test.name
+      - cm_create_object.current.description == nm_create_object.current.description == 'Initial object'
+```
+
+## Update
+
+Update all supported mutable attributes. Assert all relevant current attributes
+for the check-mode result, normal result, and idempotent repeat. Use full
+current-object comparisons when the response shape is stable; otherwise assert
+each managed attribute individually. When the module updates a parent object or
+replaces a complete nested collection, also verify that unspecified attributes
+and child objects are preserved. The child may be managed by a separate module
+and may not be exposed as an attribute of the parent module. A separate
+sibling-preservation check is not needed merely because the managed object
+belongs to a collection; it applies when the update can replace the parent or
+complete collection. For a nested collection, use an existing later query to
+compare an unaffected sibling with
+its pre-update result instead of adding another query. Parent references outside
+the module's returned object only need separate verification when preserving
+them is part of the module's contract:
+
+```yaml
+- name: Update all mutable attributes in check mode
+  cisco.mso.<module_name>: &object_updated
+    <<: *object_present
+    description: Updated object
+  check_mode: true
+  register: cm_update_object
+
+- name: Update all mutable attributes
+  cisco.mso.<module_name>:
+    <<: *object_updated
+  register: nm_update_object
+
+- name: Update object again
+  cisco.mso.<module_name>:
+    <<: *object_updated
+  register: nm_update_object_again
+
+- name: Verify update, idempotency, and preservation
+  ansible.builtin.assert:
+    that:
+      - cm_update_object is changed
+      - nm_update_object is changed
+      - nm_update_object_again is not changed
+      - cm_update_object.current.name == nm_update_object.current.name == mso_test.name
+      - cm_update_object.current.description == nm_update_object.current.description == 'Updated object'
+      # Assert every other supported attribute in each result. For nested
+      # resources, also assert that unspecified attributes and child objects
+      # remain unchanged.
+```
+
+### Preserve child objects during parent updates
+
+When a module updates a parent object that contains child objects managed by a
+separate module, or replaces a complete nested collection, and child
+preservation is part of its contract, create or define at least one child with
+the child module before updating the parent. The parent module does not need to
+expose the child's attributes. Update only the parent-managed attributes; do not
+manage the child as part of that parent update. After the normal update, query
+the child directly or use a later child query already present in the test. A
+successful query confirms that the child still exists; a missing child causes
+the query to fail. Do not rely only on the parent response, because the child
+may not be included there even when it was preserved. Repeat the parent update
+to verify idempotency as usual. Do not apply this check merely because the
+target object is one member of a collection; a module that updates only the
+selected child should verify that child's managed attributes instead.
+
+This catches a PATCH behavior where the request sends only the updated parent
+object. The controller can treat that object as a replacement and remove
+children that were not included in the request. This is a known issue in some
+older modules; affected modules have already been identified and tracked for
+future fixes. Keep the direct child query in the test so the behavior is
+visible until the module is corrected.
+
+```yaml
+- name: Create child object with its dedicated module before updating the parent
+  cisco.mso.<child_module>:
+    <<: *child_present
+  register: nm_create_child
+
+- name: Update parent without managing the child object
+  cisco.mso.<parent_module>: &parent_updated
+    <<: *parent_present
+    description: Updated parent
+  register: nm_update_parent
+
+- name: Query child after parent update
+  cisco.mso.<child_module>:
+    <<: *child_query
+    state: query
+```
+
+## Query
+
+Query an individual object when supported. Run the query in check mode as well
+and assert all returned attributes:
+
+```yaml
+- name: Query an individual object in check mode
+  cisco.mso.<module_name>: &object_query
+    <<: *object_present
+    state: query
+  check_mode: true
+  register: cm_query_object
+
+- name: Query an individual object
+  cisco.mso.<module_name>:
+    <<: *object_query
+  register: nm_query_object
+
+- name: Verify individual query
+  ansible.builtin.assert:
+    that:
+      - cm_query_object is not changed
+      - nm_query_object is not changed
+      - cm_query_object.current.name == nm_query_object.current.name == mso_test.name
+      - cm_query_object.current.description == nm_query_object.current.description == 'Initial object'
+```
+
+## Query all
+
+The object created by the preceding lifecycle also belongs to the queried
+collection and counts toward the result. Create one additional object
+specifically for the collection query in normal mode; separate check-mode
+fixture creation is not needed when check mode is already covered by the
+lifecycle scenarios. Then assert a collection length greater than one, compare
+the check-mode and normal collections, and verify each expected object is
+present:
+
+```yaml
+- name: Create query-all object 1
+  cisco.mso.<module_name>:
+    <<: *mso_info
+    name: query_all_object_1
+
+- name: Query all objects in check mode
+  cisco.mso.<module_name>: &query_all
+    <<: *mso_info
+    state: query
+  check_mode: true
+  register: cm_query_all_objects
+
+- name: Query all objects
+  cisco.mso.<module_name>:
+    <<: *query_all
+  register: nm_query_all_objects
+
+- name: Verify collection query
+  ansible.builtin.assert:
+    that:
+      - cm_query_all_objects is not changed
+      - nm_query_all_objects is not changed
+      - cm_query_all_objects.current == nm_query_all_objects.current
+      - cm_query_all_objects.current | length > 1
+      - cm_query_all_objects.current | selectattr('name', 'equalto', mso_test.name) | list | length == 1
+      - cm_query_all_objects.current | selectattr('name', 'equalto', 'query_all_object_1') | list | length == 1
+```
+
+The direct collection comparison verifies the complete returned objects, while
+the membership assertions make the expected collection contents explicit. Do
+not add query-all coverage for a module whose API does not support it.
+
+## Delete
+
+Verify check mode, normal deletion, absence through repeated deletion, and
+idempotency. Assert the complete prior object and that the proposed/current
+results are empty after deletion:
+
+```yaml
+- name: Delete object in check mode
+  cisco.mso.<module_name>:
+    <<: *object_present
+    state: absent
+  check_mode: true
+  register: cm_delete_object
+
+- name: Delete object
+  cisco.mso.<module_name>:
+    <<: *object_present
+    state: absent
+  register: nm_delete_object
+
+- name: Delete object again
+  cisco.mso.<module_name>:
+    <<: *object_present
+    state: absent
+  register: nm_delete_object_again
+
+- name: Verify delete, absence, and idempotency
+  ansible.builtin.assert:
+    that:
+      - cm_delete_object is changed
+      - nm_delete_object is changed
+      - cm_delete_object.previous.name == nm_delete_object.previous.name == mso_test.name
+      - cm_delete_object.proposed == cm_delete_object.current == {}
+      - nm_delete_object.proposed == nm_delete_object.current == {}
+      - nm_delete_object_again is not changed
+      - nm_delete_object_again.previous == nm_delete_object_again.proposed == nm_delete_object_again.current == {}
+```
+
+## Error handling
+
+Keep all expected error cases together after the lifecycle sections. Cover
+errors raised by the module and by Ansible argument-spec validation, including
+`required_if`, required values, invalid choices, and invalid object references.
+Register expected failures and assert both failure status and the relevant
+message:
+
+```yaml
+# ERROR HANDLING
+- name: Reject a missing required attribute in check mode
+  cisco.mso.<module_name>:
+    <<: *mso_info
+    name: MissingAttributeObject
+    state: present
+  check_mode: true
+  register: cm_missing_required
+  ignore_errors: true
+
+- name: Reject an invalid module argument in check mode
+  cisco.mso.<module_name>:
+    <<: *mso_info
+    name: InvalidObject
+    mode: invalid
+  check_mode: true
+  register: cm_invalid_argument
+  ignore_errors: true
+
+- name: Verify argument-spec and module error handling
+  ansible.builtin.assert:
+    that:
+      - cm_missing_required is failed
+      - cm_missing_required.msg is search('missing required arguments')
+      - cm_invalid_argument is failed
+      - cm_invalid_argument.msg is search('value of mode must be one of')
+```
+
+For a `required_if` condition, include the triggering state explicitly and
+assert the complete validation message. Include a case for each distinct
+triggering state, for example:
+
+```yaml
+- name: Reject present without subnet
+  cisco.mso.mso_schema_template_anp_epg_subnet:
+    <<: *mso_info
+    schema: '{{ mso_test.schema }}'
+    template: '{{ mso_test.template }}'
+    anp: '{{ mso_test.anp }}'
+    epg: '{{ mso_test.epg }}'
+    state: present
+  check_mode: true
+  register: cm_missing_subnet
+  ignore_errors: true
+
+- name: Verify required-if validation
+  ansible.builtin.assert:
+    that:
+      - cm_missing_subnet is failed
+      - cm_missing_subnet.msg is search('state is present but all of the following are missing: subnet')
+```
+
+## Validation
+
+Before submitting a test change:
+
+- Run [`ansible-test sanity`](https://docs.ansible.com/projects/ansible/latest/dev_guide/testing_sanity.html)
+  for module and documentation changes.
+- Run the targeted
+  [`ansible-test network-integration`](https://docs.ansible.com/projects/ansible/latest/network/dev_guide/developing_resource_modules_network.html)
+  target when access to the integration lab is available.
+- Confirm that cleanup runs on both successful and failing test paths.

--- a/README.md
+++ b/README.md
@@ -159,18 +159,20 @@ ansible_httpapi_use_ssl=True
 
 ## Testing
 
-Integration tests for each module in the `cisco.mso` collection are executed on the following Nexus Dashboard Orchestrator versions:
+Integration tests for each module in the `cisco.mso` collection are executed on the following Nexus Dashboard and Nexus Dashboard Orchestrator versions:
 
-- 3.7
-- 4.1
-- 4.2
-- 4.3
+- ND 3.2 (NDO 4.4)
+- ND 4.1 (NDO 5.1)
+- ND 4.2 (NDO 5.2)
 
 ## Contributing
 
 Ongoing development efforts and contributions to this collection are tracked as issues in this repository.
 
 We welcome community contributions to this collection. If you find problems, need an enhancement or need a new module, please open an issue or create a PR against the [Cisco MSO collection repository](https://github.com/CiscoDevNet/ansible-mso/issues).
+
+See the [Development Guide](DEVELOPMENT.md) for the integration-test structure,
+version handling, prerequisites, cleanup, and validation conventions.
 
 ## Support
 

--- a/plugins/module_utils/mso.py
+++ b/plugins/module_utils/mso.py
@@ -135,9 +135,9 @@ def mso_l3out_reference_spec():
     )
 
 
-def mso_epg_subnet_spec():
+def mso_epg_subnet_spec(subnet_required=True):
     return dict(
-        subnet=dict(type="str", required=True, aliases=["ip"]),
+        subnet=dict(type="str", required=subnet_required, aliases=["ip"]),
         description=dict(type="str"),
         scope=dict(type="str", default="private", choices=["private", "public"]),
         shared=dict(type="bool", default=False),

--- a/plugins/modules/mso_schema_site_anp_epg_subnet.py
+++ b/plugins/modules/mso_schema_site_anp_epg_subnet.py
@@ -47,8 +47,9 @@ options:
   subnet:
     description:
     - The IP range in CIDR notation.
+    - Required for C(present) and C(absent) operations.
+    - Optional for C(query); omit to query all subnets for the EPG.
     type: str
-    required: true
     aliases: [ ip ]
   description:
     description:
@@ -73,7 +74,7 @@ options:
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
-    - Use C(query) for listing an object or multiple objects.
+    - Use C(query) for listing a specific subnet or all subnets for the EPG.
     type: str
     choices: [ absent, present, query ]
     default: present
@@ -128,7 +129,7 @@ EXAMPLES = r"""
     state: query
   register: query_result
 
-- name: Query all site EPG subnets
+- name: Query all subnets for a site EPG
   cisco.mso.mso_schema_site_anp_epg_subnet:
     host: mso_host
     username: admin
@@ -137,8 +138,10 @@ EXAMPLES = r"""
     site: Site1
     template: Template1
     anp: ANP1
+    epg: EPG1
     state: query
   register: query_result
+
 """
 
 RETURN = r"""
@@ -158,7 +161,7 @@ def main():
         epg=dict(type="str", required=True),
         state=dict(type="str", default="present", choices=["absent", "present", "query"]),
     )
-    argument_spec.update(mso_epg_subnet_spec())
+    argument_spec.update(mso_epg_subnet_spec(subnet_required=False))
 
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -194,7 +197,8 @@ def main():
         mso.fail_json(msg="No site associated with template '{0}'. Associate the site with the template using mso_schema_site.".format(template))
     sites = [(s.get("siteId"), s.get("templateName")) for s in schema_obj.get("sites")]
     if (site_id, template) not in sites:
-        mso.fail_json(msg="Provided site/template '{0}-{1}' does not exist. Existing sites/templates: {2}".format(site, template, ", ".join(sites)))
+        existing_sites_templates = ", ".join("{0}-{1}".format(site_id, template_name) for site_id, template_name in sites)
+        mso.fail_json(msg="Provided site/template '{0}-{1}' does not exist. Existing sites/templates: {2}".format(site, template, existing_sites_templates))
 
     # Schema-access uses indexes
     site_idx = sites.index((site_id, template))
@@ -243,12 +247,6 @@ def main():
         if not mso.existing:
             if description is None:
                 description = subnet
-            if scope is None:
-                scope = "private"
-            if shared is None:
-                shared = False
-            if no_default_gateway is None:
-                no_default_gateway = False
 
         payload = dict(
             ip=subnet,

--- a/plugins/modules/mso_schema_template_anp_epg.py
+++ b/plugins/modules/mso_schema_template_anp_epg.py
@@ -265,11 +265,6 @@ EXAMPLES = r"""
     schema: Schema 1
     template: Template 1
     anp: ANP 1
-    epg: EPG 1
-    bd:
-      name: bd1
-    vrf:
-      name: vrf1
     state: query
   register: query_result
 """

--- a/plugins/modules/mso_schema_template_anp_epg_subnet.py
+++ b/plugins/modules/mso_schema_template_anp_epg_subnet.py
@@ -42,8 +42,9 @@ options:
   subnet:
     description:
     - The IP range in CIDR notation.
+    - Required for C(present) and C(absent) operations.
+    - Optional for C(query); omit to query all subnets for the EPG.
     type: str
-    required: true
     aliases: [ ip ]
   description:
     description:
@@ -68,7 +69,7 @@ options:
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
-    - Use C(query) for listing an object or multiple objects.
+    - Use C(query) for listing a specific subnet or all subnets for the EPG.
     type: str
     choices: [ absent, present, query ]
     default: present
@@ -115,7 +116,7 @@ EXAMPLES = r"""
     state: query
   register: query_result
 
-- name: Query all EPGs subnets
+- name: Query all subnets for an EPG
   cisco.mso.mso_schema_template_anp_epg_subnet:
     host: mso_host
     username: admin
@@ -123,8 +124,10 @@ EXAMPLES = r"""
     schema: Schema 1
     template: Template 1
     anp: ANP 1
+    epg: EPG 1
     state: query
   register: query_result
+
 """
 
 RETURN = r"""
@@ -143,7 +146,7 @@ def main():
         epg=dict(type="str", required=True),
         state=dict(type="str", default="present", choices=["absent", "present", "query"]),
     )
-    argument_spec.update(mso_epg_subnet_spec())
+    argument_spec.update(mso_epg_subnet_spec(subnet_required=False))
 
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -218,12 +221,6 @@ def main():
         if not mso.existing:
             if description is None:
                 description = subnet
-            if scope is None:
-                scope = "private"
-            if shared is None:
-                shared = False
-            if no_default_gateway is None:
-                no_default_gateway = False
 
         payload = dict(
             ip=subnet,

--- a/tests/integration/targets/mso_schema_site_anp_epg_subnet/aliases
+++ b/tests/integration/targets/mso_schema_site_anp_epg_subnet/aliases
@@ -1,0 +1,3 @@
+# The module and integration test are supported.
+# Uncomment the following line to exclude this test target when necessary.
+# unsupported

--- a/tests/integration/targets/mso_schema_site_anp_epg_subnet/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_subnet/tasks/main.yml
@@ -1,0 +1,536 @@
+---
+# Test code for the MSO modules
+# Copyright: (c) 2026, Cisco Systems, Inc.
+# Copyright: (c) 2026, Akini Ross (@akinross) <akinross@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that required ACI MultiSite variables are defined
+  ansible.builtin.fail:
+    msg: 'Please define mso_hostname, mso_username and mso_password.'
+  when: >
+    mso_hostname is not defined or mso_username is not defined or mso_password is not defined
+
+- name: Set test connection and fixture variables
+  ansible.builtin.set_fact:
+    mso_info: &mso_info
+      host: '{{ mso_hostname }}'
+      username: '{{ mso_username }}'
+      password: '{{ mso_password }}'
+      validate_certs: '{{ mso_validate_certs | default(false) }}'
+      use_ssl: '{{ mso_use_ssl | default(true) }}'
+      use_proxy: '{{ mso_use_proxy | default(true) }}'
+      output_level: debug
+    mso_test:
+      schema: '{{ mso_schema_site_anp_epg_subnet | default(mso_schema | default("ansible_test")) }}'
+      tenant: '{{ mso_tenant_site_anp_epg_subnet | default(mso_tenant | default("ansible_test")) }}'
+      site: '{{ mso_site_anp_epg_subnet | default(mso_site | default("ansible_test")) }}'
+      template: Template1
+      anp: ANP1
+      epg: EPG1
+      bd: BD1
+      vrf: VRF1
+
+- name: Exercise mso_schema_site_anp_epg_subnet
+  block:
+
+  # CLEAN ENVIRONMENT
+  # Due to API changes in ND 4.2, the configured site and tenant are
+  # prerequisites for this test and must already exist. They are intentionally
+  # not created or queried here.
+  - name: Remove test schema before testing
+    cisco.mso.mso_schema:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      state: absent
+
+  - name: Ensure schema and template exist
+    cisco.mso.mso_schema_template:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      tenant: '{{ mso_test.tenant }}'
+      template: '{{ mso_test.template }}'
+
+  - name: Associate the site with the schema template
+    cisco.mso.mso_schema_site:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      site: '{{ mso_test.site }}'
+      template: '{{ mso_test.template }}'
+
+  - name: Ensure VRF exists
+    cisco.mso.mso_schema_template_vrf:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      vrf: '{{ mso_test.vrf }}'
+
+  - name: Ensure bridge domain exists
+    cisco.mso.mso_schema_template_bd:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      bd: '{{ mso_test.bd }}'
+      vrf:
+        name: '{{ mso_test.vrf }}'
+
+  - name: Ensure template ANP exists
+    cisco.mso.mso_schema_template_anp:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+
+  - name: Ensure template EPG exists with parent references
+    cisco.mso.mso_schema_template_anp_epg:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      bd:
+        name: '{{ mso_test.bd }}'
+      vrf:
+        name: '{{ mso_test.vrf }}'
+
+  - name: Ensure site ANP exists
+    cisco.mso.mso_schema_site_anp:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+
+  - name: Ensure site EPG exists
+    cisco.mso.mso_schema_site_anp_epg:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+
+  # CREATE
+  - name: Create subnet 1 with all supported attributes in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet: &subnet_1_present
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      subnet: 10.10.1.1/24
+      description: Site subnet 1
+      scope: public
+      shared: true
+      no_default_gateway: true
+    check_mode: true
+    register: cm_create_subnet_1
+
+  - name: Create subnet 1
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *subnet_1_present
+    register: nm_create_subnet_1
+
+  - name: Create subnet 1 again
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *subnet_1_present
+    register: nm_create_subnet_1_again
+
+  # Create results contain the module payload, while subsequent reads may include controller-generated attributes.
+  # Assert the managed attributes individually so the create and idempotency checks do not compare different response shapes.
+  - name: Verify subnet 1 create and idempotency scenarios
+    ansible.builtin.assert:
+      that:
+      - cm_create_subnet_1 is changed
+      - cm_create_subnet_1.previous == {}
+      - cm_create_subnet_1.proposed == cm_create_subnet_1.current
+      - cm_create_subnet_1.current.ip == '10.10.1.1/24'
+      - cm_create_subnet_1.current.description == 'Site subnet 1'
+      - cm_create_subnet_1.current.scope == 'public'
+      - cm_create_subnet_1.current.shared
+      - cm_create_subnet_1.current.noDefaultGateway
+      - nm_create_subnet_1 is changed
+      - nm_create_subnet_1.previous == {}
+      - nm_create_subnet_1.proposed == nm_create_subnet_1.current
+      - nm_create_subnet_1.current.ip == '10.10.1.1/24'
+      - nm_create_subnet_1.current.description == 'Site subnet 1'
+      - nm_create_subnet_1.current.scope == 'public'
+      - nm_create_subnet_1.current.shared
+      - nm_create_subnet_1.current.noDefaultGateway
+      - nm_create_subnet_1_again is not changed
+      - nm_create_subnet_1_again.previous.ip == nm_create_subnet_1.current.ip
+      - nm_create_subnet_1_again.previous.description == nm_create_subnet_1.current.description
+      - nm_create_subnet_1_again.previous.scope == nm_create_subnet_1.current.scope
+      - nm_create_subnet_1_again.previous.shared == nm_create_subnet_1.current.shared
+      - nm_create_subnet_1_again.previous.noDefaultGateway == nm_create_subnet_1.current.noDefaultGateway
+      - nm_create_subnet_1_again.proposed.ip == nm_create_subnet_1.current.ip
+      - nm_create_subnet_1_again.proposed.description == nm_create_subnet_1.current.description
+      - nm_create_subnet_1_again.proposed.scope == nm_create_subnet_1.current.scope
+      - nm_create_subnet_1_again.proposed.shared == nm_create_subnet_1.current.shared
+      - nm_create_subnet_1_again.proposed.noDefaultGateway == nm_create_subnet_1.current.noDefaultGateway
+      - nm_create_subnet_1_again.current.ip == nm_create_subnet_1.current.ip
+      - nm_create_subnet_1_again.current.description == nm_create_subnet_1.current.description
+      - nm_create_subnet_1_again.current.scope == nm_create_subnet_1.current.scope
+      - nm_create_subnet_1_again.current.shared == nm_create_subnet_1.current.shared
+      - nm_create_subnet_1_again.current.noDefaultGateway == nm_create_subnet_1.current.noDefaultGateway
+
+  - name: Create subnet 2 with the ip alias and omitted optionals in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet: &subnet_2_present
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      ip: 10.10.2.1/24
+    check_mode: true
+    register: cm_create_subnet_2
+
+  - name: Create subnet 2 with defaults
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *subnet_2_present
+    register: nm_create_subnet_2
+
+  - name: Create subnet 2 again
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *subnet_2_present
+    register: nm_create_subnet_2_again
+
+  # Assert the managed attributes individually for the same create-versus-read response-shape difference described above.
+  - name: Verify subnet 2 defaults and check mode
+    ansible.builtin.assert:
+      that:
+      - cm_create_subnet_2 is changed
+      - cm_create_subnet_2.previous == {}
+      - cm_create_subnet_2.proposed == cm_create_subnet_2.current
+      - cm_create_subnet_2.current.ip == '10.10.2.1/24'
+      - cm_create_subnet_2.current.description == '10.10.2.1/24'
+      - cm_create_subnet_2.current.scope == 'private'
+      - cm_create_subnet_2.current.shared == false
+      - cm_create_subnet_2.current.noDefaultGateway == false
+      - nm_create_subnet_2 is changed
+      - nm_create_subnet_2.previous == {}
+      - nm_create_subnet_2.proposed == nm_create_subnet_2.current
+      - nm_create_subnet_2.current.ip == '10.10.2.1/24'
+      - nm_create_subnet_2.current.description == '10.10.2.1/24'
+      - nm_create_subnet_2.current.scope == 'private'
+      - nm_create_subnet_2.current.shared == false
+      - nm_create_subnet_2.current.noDefaultGateway == false
+      - nm_create_subnet_2_again is not changed
+      - nm_create_subnet_2_again.previous.ip == nm_create_subnet_2.current.ip
+      - nm_create_subnet_2_again.previous.description == nm_create_subnet_2.current.description
+      - nm_create_subnet_2_again.previous.scope == nm_create_subnet_2.current.scope
+      - nm_create_subnet_2_again.previous.shared == nm_create_subnet_2.current.shared
+      - nm_create_subnet_2_again.previous.noDefaultGateway == nm_create_subnet_2.current.noDefaultGateway
+      - nm_create_subnet_2_again.proposed.ip == nm_create_subnet_2.current.ip
+      - nm_create_subnet_2_again.proposed.description == nm_create_subnet_2.current.description
+      - nm_create_subnet_2_again.proposed.scope == nm_create_subnet_2.current.scope
+      - nm_create_subnet_2_again.proposed.shared == nm_create_subnet_2.current.shared
+      - nm_create_subnet_2_again.proposed.noDefaultGateway == nm_create_subnet_2.current.noDefaultGateway
+      - nm_create_subnet_2_again.current.ip == nm_create_subnet_2.current.ip
+      - nm_create_subnet_2_again.current.description == nm_create_subnet_2.current.description
+      - nm_create_subnet_2_again.current.scope == nm_create_subnet_2.current.scope
+      - nm_create_subnet_2_again.current.shared == nm_create_subnet_2.current.shared
+      - nm_create_subnet_2_again.current.noDefaultGateway == nm_create_subnet_2.current.noDefaultGateway
+
+  # UPDATE
+  - name: Update all mutable attributes of subnet 1 in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet: &subnet_1_updated
+      <<: *subnet_1_present
+      description: Updated site subnet 1
+      scope: private
+      shared: false
+      no_default_gateway: false
+    check_mode: true
+    register: cm_update_subnet_1
+
+  - name: Update all mutable attributes of subnet 1
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *subnet_1_updated
+    register: nm_update_subnet_1
+
+  - name: Update subnet 1 again
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *subnet_1_updated
+    register: nm_update_subnet_1_again
+
+  - name: Verify subnet 1 update and idempotency
+    ansible.builtin.assert:
+      that:
+      - cm_update_subnet_1 is changed
+      - cm_update_subnet_1.previous.ip == '10.10.1.1/24'
+      - cm_update_subnet_1.previous.description == 'Site subnet 1'
+      - cm_update_subnet_1.previous.scope == 'public'
+      - cm_update_subnet_1.previous.shared
+      - cm_update_subnet_1.previous.noDefaultGateway
+      - cm_update_subnet_1.proposed == cm_update_subnet_1.current
+      - cm_update_subnet_1.current.ip == '10.10.1.1/24'
+      - cm_update_subnet_1.current.description == 'Updated site subnet 1'
+      - cm_update_subnet_1.current.scope == 'private'
+      - cm_update_subnet_1.current.shared == false
+      - cm_update_subnet_1.current.noDefaultGateway == false
+      - nm_update_subnet_1 is changed
+      - nm_update_subnet_1.previous.ip == '10.10.1.1/24'
+      - nm_update_subnet_1.previous.description == 'Site subnet 1'
+      - nm_update_subnet_1.previous.scope == 'public'
+      - nm_update_subnet_1.previous.shared
+      - nm_update_subnet_1.previous.noDefaultGateway
+      - nm_update_subnet_1.proposed == nm_update_subnet_1.current
+      - nm_update_subnet_1.current.ip == '10.10.1.1/24'
+      - nm_update_subnet_1.current.description == 'Updated site subnet 1'
+      - nm_update_subnet_1.current.scope == 'private'
+      - nm_update_subnet_1.current.shared == false
+      - nm_update_subnet_1.current.noDefaultGateway == false
+      - nm_update_subnet_1_again is not changed
+      - nm_update_subnet_1_again.previous == nm_update_subnet_1.current
+      - nm_update_subnet_1_again.proposed == nm_update_subnet_1_again.current == nm_update_subnet_1.current
+
+  # QUERY
+  - name: Query subnet 1 in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet: &subnet_1_query
+      <<: *subnet_1_present
+      state: query
+    check_mode: true
+    register: cm_query_subnet_1
+
+  - name: Query subnet 1
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *subnet_1_query
+    register: nm_query_subnet_1
+
+  - name: Create subnet 3 for query-all coverage
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      subnet: 10.10.3.1/24
+      description: Site subnet 3
+      scope: public
+      shared: false
+      no_default_gateway: false
+
+  - name: Query all site EPG subnets in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet: &all_subnets_query
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      state: query
+    check_mode: true
+    register: cm_query_all_subnets
+
+  - name: Query all site EPG subnets
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *all_subnets_query
+    register: nm_query_all_subnets
+
+  - name: Verify individual query
+    ansible.builtin.assert:
+      that:
+      - cm_query_subnet_1 is not changed
+      - nm_query_subnet_1 is not changed
+      - cm_query_subnet_1.current == nm_query_subnet_1.current == nm_update_subnet_1.current
+      - cm_query_subnet_1.current.ip == nm_query_subnet_1.current.ip == '10.10.1.1/24'
+      - cm_query_subnet_1.current.description == nm_query_subnet_1.current.description == 'Updated site subnet 1'
+      - cm_query_subnet_1.current.scope == nm_query_subnet_1.current.scope == 'private'
+      - cm_query_subnet_1.current.shared == nm_query_subnet_1.current.shared == false
+      - cm_query_subnet_1.current.noDefaultGateway == nm_query_subnet_1.current.noDefaultGateway == false
+
+  - name: Verify collection query
+    ansible.builtin.assert:
+      that:
+      - cm_query_all_subnets is not changed
+      - nm_query_all_subnets is not changed
+      - cm_query_all_subnets.current == nm_query_all_subnets.current
+      - cm_query_all_subnets.current | length == nm_query_all_subnets.current | length == 3
+      - cm_query_all_subnets.current | selectattr('ip', 'equalto', '10.10.1.1/24') | list | length == 1
+      - cm_query_all_subnets.current | selectattr('ip', 'equalto', '10.10.2.1/24') | list | length == 1
+      - cm_query_all_subnets.current | selectattr('ip', 'equalto', '10.10.3.1/24') | list | length == 1
+
+  # DELETE
+  - name: Delete subnet 1 in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *subnet_1_present
+      state: absent
+    check_mode: true
+    register: cm_delete_subnet_1
+
+  - name: Delete subnet 1
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *subnet_1_present
+      state: absent
+    register: nm_delete_subnet_1
+
+  - name: Delete subnet 1 again
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *subnet_1_present
+      state: absent
+    register: nm_delete_subnet_1_again
+
+  - name: Verify subnet 1 delete, absence, and idempotency
+    ansible.builtin.assert:
+      that:
+      - cm_delete_subnet_1 is changed
+      - cm_delete_subnet_1.previous == nm_update_subnet_1.current
+      - cm_delete_subnet_1.proposed == cm_delete_subnet_1.current == {}
+      - nm_delete_subnet_1 is changed
+      - nm_delete_subnet_1.previous == nm_update_subnet_1.current
+      - nm_delete_subnet_1.proposed == nm_delete_subnet_1.current == {}
+      - nm_delete_subnet_1_again is not changed
+      - nm_delete_subnet_1_again.previous == nm_delete_subnet_1_again.proposed == nm_delete_subnet_1_again.current == {}
+
+  # ERROR HANDLING
+  - name: Query nonexistent subnet in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *subnet_1_present
+      subnet: 10.10.99.1/24
+      state: query
+    check_mode: true
+    register: cm_query_missing
+    ignore_errors: true
+
+  - name: Query a missing schema in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: MissingSchema
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      subnet: 10.10.4.1/24
+      state: query
+    check_mode: true
+    register: cm_missing_schema
+    ignore_errors: true
+
+  - name: Query a missing site in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *mso_info
+      site: MissingSite
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      subnet: 10.10.4.1/24
+      state: query
+    check_mode: true
+    register: cm_missing_site
+    ignore_errors: true
+
+  - name: Query a missing template in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: MissingTemplate
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      subnet: 10.10.4.1/24
+      state: query
+    check_mode: true
+    register: cm_missing_template
+    ignore_errors: true
+
+  - name: Query a missing ANP in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: MissingANP
+      epg: '{{ mso_test.epg }}'
+      subnet: 10.10.4.1/24
+      state: query
+    check_mode: true
+    register: cm_missing_anp
+    ignore_errors: true
+
+  - name: Query a missing EPG in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: MissingEPG
+      subnet: 10.10.4.1/24
+      state: query
+    check_mode: true
+    register: cm_missing_epg
+    ignore_errors: true
+
+  - name: Reject an invalid subnet scope in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      subnet: 10.10.4.1/24
+      scope: invalid
+    check_mode: true
+    register: cm_invalid_scope
+    ignore_errors: true
+
+  - name: Reject a missing subnet in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      state: present
+    check_mode: true
+    register: cm_missing_subnet
+    ignore_errors: true
+
+  - name: Reject an absent subnet without subnet in check mode
+    cisco.mso.mso_schema_site_anp_epg_subnet:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      state: absent
+    check_mode: true
+    register: cm_missing_subnet_absent
+    ignore_errors: true
+
+  - name: Verify error-handling scenarios
+    ansible.builtin.assert:
+      that:
+      - cm_query_missing is failed
+      - cm_query_missing.msg is search("Subnet '10.10.99.1/24' not found")
+      - cm_missing_schema is failed
+      - cm_missing_schema.msg is search("Provided schema 'MissingSchema' does not exist")
+      - cm_missing_site is failed
+      - cm_missing_site.msg is search("Site 'MissingSite' is not a valid site name")
+      - cm_missing_template is failed
+      - "cm_missing_template.msg is search(\"Provided site/template '\" ~ mso_test.site ~ \"-MissingTemplate' does not exist\")"
+      - cm_missing_anp is failed
+      - cm_missing_anp.msg is search("Provided anp 'MissingANP' does not exist")
+      - cm_missing_epg is failed
+      - cm_missing_epg.msg is search("Provided epg 'MissingEPG' does not exist")
+      - cm_invalid_scope is failed
+      - cm_invalid_scope.msg is search('value of scope must be one of')
+      - cm_missing_subnet is failed
+      - "cm_missing_subnet.msg is search('state is present but all of the following are missing: subnet')"
+      - cm_missing_subnet_absent is failed
+      - "cm_missing_subnet_absent.msg is search('state is absent but all of the following are missing: subnet')"
+
+  always:
+  # CLEANUP
+  - name: Remove test schema even when a test fails
+    cisco.mso.mso_schema:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      state: absent

--- a/tests/integration/targets/mso_schema_template_anp_epg_subnet/aliases
+++ b/tests/integration/targets/mso_schema_template_anp_epg_subnet/aliases
@@ -1,0 +1,3 @@
+# The module and integration test are supported.
+# Uncomment the following line to exclude this test target when necessary.
+# unsupported

--- a/tests/integration/targets/mso_schema_template_anp_epg_subnet/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_template_anp_epg_subnet/tasks/main.yml
@@ -1,0 +1,493 @@
+---
+# Test code for the MSO modules
+# Copyright: (c) 2026, Cisco Systems, Inc.
+# Copyright: (c) 2026, Akini Ross (@akinross) <akinross@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI MultiSite host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: mso_hostname, mso_username and mso_password.'
+  when: mso_hostname is not defined or mso_username is not defined or mso_password is not defined
+
+- name: Set test connection and fixture variables
+  ansible.builtin.set_fact:
+    mso_info: &mso_info
+      host: '{{ mso_hostname }}'
+      username: '{{ mso_username }}'
+      password: '{{ mso_password }}'
+      validate_certs: '{{ mso_validate_certs | default(false) }}'
+      use_ssl: '{{ mso_use_ssl | default(true) }}'
+      use_proxy: '{{ mso_use_proxy | default(true) }}'
+      output_level: debug
+    mso_test:
+      schema: '{{ mso_schema_template_anp_epg_subnet | default(mso_schema | default("ansible_test")) }}'
+      tenant: '{{ mso_tenant_template_anp_epg_subnet | default(mso_tenant | default("ansible_test")) }}'
+      template: Template1
+      anp: ANP1
+      epg: EPG1
+      bd: BD1
+      vrf: VRF1
+
+- name: Exercise mso_schema_template_anp_epg_subnet
+  block:
+
+  # CLEAN ENVIRONMENT
+  # Due to API changes in ND 4.2, the configured tenant is a prerequisite for
+  # this test and must already exist. It is intentionally not created or
+  # queried here.
+  - name: Remove test schema before testing
+    cisco.mso.mso_schema:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      state: absent
+
+  - name: Ensure schema and template exist
+    cisco.mso.mso_schema_template:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      tenant: '{{ mso_test.tenant }}'
+      template: '{{ mso_test.template }}'
+
+  - name: Ensure VRF exists
+    cisco.mso.mso_schema_template_vrf:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      vrf: '{{ mso_test.vrf }}'
+
+  - name: Ensure bridge domain exists
+    cisco.mso.mso_schema_template_bd:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      bd: '{{ mso_test.bd }}'
+      vrf:
+        name: '{{ mso_test.vrf }}'
+
+  - name: Ensure ANP exists
+    cisco.mso.mso_schema_template_anp:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+
+  - name: Ensure EPG exists with parent references
+    cisco.mso.mso_schema_template_anp_epg:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      bd:
+        name: '{{ mso_test.bd }}'
+      vrf:
+        name: '{{ mso_test.vrf }}'
+
+  # CREATE
+  - name: Create subnet 1 with all supported attributes in check mode
+    cisco.mso.mso_schema_template_anp_epg_subnet: &subnet_1_present
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      subnet: 10.10.1.1/24
+      description: Primary subnet
+      scope: public
+      shared: true
+      no_default_gateway: true
+    check_mode: true
+    register: cm_create_subnet_1
+
+  - name: Create subnet 1
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *subnet_1_present
+    register: nm_create_subnet_1
+
+  - name: Create subnet 1 again
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *subnet_1_present
+    register: nm_create_subnet_1_again
+
+  # Create results contain the module payload, while subsequent reads may include controller-generated attributes.
+  # Assert the managed attributes individually so the create and idempotency checks do not compare different response shapes.
+  - name: Verify subnet 1 create and idempotency scenarios
+    ansible.builtin.assert:
+      that:
+      - cm_create_subnet_1 is changed
+      - cm_create_subnet_1.previous == {}
+      - cm_create_subnet_1.proposed == cm_create_subnet_1.current
+      - cm_create_subnet_1.current.ip == '10.10.1.1/24'
+      - cm_create_subnet_1.current.description == 'Primary subnet'
+      - cm_create_subnet_1.current.scope == 'public'
+      - cm_create_subnet_1.current.shared
+      - cm_create_subnet_1.current.noDefaultGateway
+      - nm_create_subnet_1 is changed
+      - nm_create_subnet_1.previous == {}
+      - nm_create_subnet_1.proposed == nm_create_subnet_1.current
+      - nm_create_subnet_1.current.ip == '10.10.1.1/24'
+      - nm_create_subnet_1.current.description == 'Primary subnet'
+      - nm_create_subnet_1.current.scope == 'public'
+      - nm_create_subnet_1.current.shared
+      - nm_create_subnet_1.current.noDefaultGateway
+      - nm_create_subnet_1_again is not changed
+      - nm_create_subnet_1_again.previous.ip == nm_create_subnet_1.current.ip
+      - nm_create_subnet_1_again.previous.description == nm_create_subnet_1.current.description
+      - nm_create_subnet_1_again.previous.scope == nm_create_subnet_1.current.scope
+      - nm_create_subnet_1_again.previous.shared == nm_create_subnet_1.current.shared
+      - nm_create_subnet_1_again.previous.noDefaultGateway == nm_create_subnet_1.current.noDefaultGateway
+      - nm_create_subnet_1_again.proposed.ip == nm_create_subnet_1.current.ip
+      - nm_create_subnet_1_again.proposed.description == nm_create_subnet_1.current.description
+      - nm_create_subnet_1_again.proposed.scope == nm_create_subnet_1.current.scope
+      - nm_create_subnet_1_again.proposed.shared == nm_create_subnet_1.current.shared
+      - nm_create_subnet_1_again.proposed.noDefaultGateway == nm_create_subnet_1.current.noDefaultGateway
+      - nm_create_subnet_1_again.current.ip == nm_create_subnet_1.current.ip
+      - nm_create_subnet_1_again.current.description == nm_create_subnet_1.current.description
+      - nm_create_subnet_1_again.current.scope == nm_create_subnet_1.current.scope
+      - nm_create_subnet_1_again.current.shared == nm_create_subnet_1.current.shared
+      - nm_create_subnet_1_again.current.noDefaultGateway == nm_create_subnet_1.current.noDefaultGateway
+
+  - name: Create subnet 2 with the ip alias and omitted optionals in check mode
+    cisco.mso.mso_schema_template_anp_epg_subnet: &subnet_2_present
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      ip: 10.10.2.1/24
+    check_mode: true
+    register: cm_create_subnet_2
+
+  - name: Create subnet 2 with defaults
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *subnet_2_present
+    register: nm_create_subnet_2
+
+  - name: Create subnet 2 again
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *subnet_2_present
+    register: nm_create_subnet_2_again
+
+  # Assert the managed attributes individually for the same create-versus-read response-shape difference described above.
+  - name: Verify subnet 2 defaults and check mode
+    ansible.builtin.assert:
+      that:
+      - cm_create_subnet_2 is changed
+      - cm_create_subnet_2.previous == {}
+      - cm_create_subnet_2.proposed == cm_create_subnet_2.current
+      - cm_create_subnet_2.current.ip == '10.10.2.1/24'
+      - cm_create_subnet_2.current.description == '10.10.2.1/24'
+      - cm_create_subnet_2.current.scope == 'private'
+      - cm_create_subnet_2.current.shared == false
+      - cm_create_subnet_2.current.noDefaultGateway == false
+      - nm_create_subnet_2 is changed
+      - nm_create_subnet_2.previous == {}
+      - nm_create_subnet_2.proposed == nm_create_subnet_2.current
+      - nm_create_subnet_2.current.ip == '10.10.2.1/24'
+      - nm_create_subnet_2.current.description == '10.10.2.1/24'
+      - nm_create_subnet_2.current.scope == 'private'
+      - nm_create_subnet_2.current.shared == false
+      - nm_create_subnet_2.current.noDefaultGateway == false
+      - nm_create_subnet_2_again is not changed
+      - nm_create_subnet_2_again.previous.ip == nm_create_subnet_2.current.ip
+      - nm_create_subnet_2_again.previous.description == nm_create_subnet_2.current.description
+      - nm_create_subnet_2_again.previous.scope == nm_create_subnet_2.current.scope
+      - nm_create_subnet_2_again.previous.shared == nm_create_subnet_2.current.shared
+      - nm_create_subnet_2_again.previous.noDefaultGateway == nm_create_subnet_2.current.noDefaultGateway
+      - nm_create_subnet_2_again.proposed.ip == nm_create_subnet_2.current.ip
+      - nm_create_subnet_2_again.proposed.description == nm_create_subnet_2.current.description
+      - nm_create_subnet_2_again.proposed.scope == nm_create_subnet_2.current.scope
+      - nm_create_subnet_2_again.proposed.shared == nm_create_subnet_2.current.shared
+      - nm_create_subnet_2_again.proposed.noDefaultGateway == nm_create_subnet_2.current.noDefaultGateway
+      - nm_create_subnet_2_again.current.ip == nm_create_subnet_2.current.ip
+      - nm_create_subnet_2_again.current.description == nm_create_subnet_2.current.description
+      - nm_create_subnet_2_again.current.scope == nm_create_subnet_2.current.scope
+      - nm_create_subnet_2_again.current.shared == nm_create_subnet_2.current.shared
+      - nm_create_subnet_2_again.current.noDefaultGateway == nm_create_subnet_2.current.noDefaultGateway
+
+  # UPDATE
+  - name: Update all mutable attributes of subnet 1 in check mode
+    cisco.mso.mso_schema_template_anp_epg_subnet: &subnet_1_updated
+      <<: *subnet_1_present
+      description: Updated subnet 1
+      scope: private
+      shared: false
+      no_default_gateway: false
+    check_mode: true
+    register: cm_update_subnet_1
+
+  - name: Update all mutable attributes of subnet 1
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *subnet_1_updated
+    register: nm_update_subnet_1
+
+  - name: Update subnet 1 again
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *subnet_1_updated
+    register: nm_update_subnet_1_again
+
+  - name: Verify subnet 1 update and idempotency
+    ansible.builtin.assert:
+      that:
+      - cm_update_subnet_1 is changed
+      - cm_update_subnet_1.previous.ip == '10.10.1.1/24'
+      - cm_update_subnet_1.previous.description == 'Primary subnet'
+      - cm_update_subnet_1.previous.scope == 'public'
+      - cm_update_subnet_1.previous.shared
+      - cm_update_subnet_1.previous.noDefaultGateway
+      - cm_update_subnet_1.proposed == cm_update_subnet_1.current
+      - cm_update_subnet_1.current.ip == '10.10.1.1/24'
+      - cm_update_subnet_1.current.description == 'Updated subnet 1'
+      - cm_update_subnet_1.current.scope == 'private'
+      - cm_update_subnet_1.current.shared == false
+      - cm_update_subnet_1.current.noDefaultGateway == false
+      - nm_update_subnet_1 is changed
+      - nm_update_subnet_1.previous.ip == '10.10.1.1/24'
+      - nm_update_subnet_1.previous.description == 'Primary subnet'
+      - nm_update_subnet_1.previous.scope == 'public'
+      - nm_update_subnet_1.previous.shared
+      - nm_update_subnet_1.previous.noDefaultGateway
+      - nm_update_subnet_1.proposed == nm_update_subnet_1.current
+      - nm_update_subnet_1.current.ip == '10.10.1.1/24'
+      - nm_update_subnet_1.current.description == 'Updated subnet 1'
+      - nm_update_subnet_1.current.scope == 'private'
+      - nm_update_subnet_1.current.shared == false
+      - nm_update_subnet_1.current.noDefaultGateway == false
+      - nm_update_subnet_1_again is not changed
+      - nm_update_subnet_1_again.previous == nm_update_subnet_1.current
+      - nm_update_subnet_1_again.proposed == nm_update_subnet_1_again.current == nm_update_subnet_1.current
+
+  # QUERY
+  - name: Query subnet 1 in check mode
+    cisco.mso.mso_schema_template_anp_epg_subnet: &subnet_1_query
+      <<: *subnet_1_present
+      state: query
+    check_mode: true
+    register: cm_query_subnet_1
+
+  - name: Query subnet 1
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *subnet_1_query
+    register: nm_query_subnet_1
+
+  - name: Create subnet 3 for query-all coverage
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      subnet: 10.10.3.1/24
+      description: Subnet 3
+      scope: public
+      shared: false
+      no_default_gateway: false
+
+  - name: Query all EPG subnets in check mode
+    cisco.mso.mso_schema_template_anp_epg_subnet: &all_subnets_query
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      state: query
+    check_mode: true
+    register: cm_query_all_subnets
+
+  - name: Query all EPG subnets
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *all_subnets_query
+    register: nm_query_all_subnets
+
+  - name: Verify individual query
+    ansible.builtin.assert:
+      that:
+      - cm_query_subnet_1 is not changed
+      - nm_query_subnet_1 is not changed
+      - cm_query_subnet_1.current == nm_query_subnet_1.current == nm_update_subnet_1.current
+      - cm_query_subnet_1.current.ip == nm_query_subnet_1.current.ip == '10.10.1.1/24'
+      - cm_query_subnet_1.current.description == nm_query_subnet_1.current.description == 'Updated subnet 1'
+      - cm_query_subnet_1.current.scope == nm_query_subnet_1.current.scope == 'private'
+      - cm_query_subnet_1.current.shared == nm_query_subnet_1.current.shared == false
+      - cm_query_subnet_1.current.noDefaultGateway == nm_query_subnet_1.current.noDefaultGateway == false
+
+  - name: Verify collection query
+    ansible.builtin.assert:
+      that:
+      - cm_query_all_subnets is not changed
+      - nm_query_all_subnets is not changed
+      - cm_query_all_subnets.current == nm_query_all_subnets.current
+      - cm_query_all_subnets.current | length == nm_query_all_subnets.current | length == 3
+      - cm_query_all_subnets.current | selectattr('ip', 'equalto', '10.10.1.1/24') | list | length == 1
+      - cm_query_all_subnets.current | selectattr('ip', 'equalto', '10.10.2.1/24') | list | length == 1
+      - cm_query_all_subnets.current | selectattr('ip', 'equalto', '10.10.3.1/24') | list | length == 1
+
+  # DELETE
+  - name: Delete subnet 1 in check mode
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *subnet_1_present
+      state: absent
+    check_mode: true
+    register: cm_delete_subnet_1
+
+  - name: Delete subnet 1
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *subnet_1_present
+      state: absent
+    register: nm_delete_subnet_1
+
+  - name: Delete subnet 1 again
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *subnet_1_present
+      state: absent
+    register: nm_delete_subnet_1_again
+
+  - name: Verify subnet 1 delete, absence, and idempotency
+    ansible.builtin.assert:
+      that:
+      - cm_delete_subnet_1 is changed
+      - cm_delete_subnet_1.previous == nm_update_subnet_1.current
+      - cm_delete_subnet_1.proposed == cm_delete_subnet_1.current == {}
+      - nm_delete_subnet_1 is changed
+      - nm_delete_subnet_1.previous == nm_update_subnet_1.current
+      - nm_delete_subnet_1.proposed == nm_delete_subnet_1.current == {}
+      - nm_delete_subnet_1_again is not changed
+      - nm_delete_subnet_1_again.previous == nm_delete_subnet_1_again.proposed == nm_delete_subnet_1_again.current == {}
+
+  # ERROR HANDLING
+  - name: Query nonexistent subnet in check mode
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *subnet_1_present
+      subnet: 10.10.99.1/24
+      state: query
+    check_mode: true
+    register: cm_query_missing
+    ignore_errors: true
+
+  - name: Query nonexistent subnet
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *subnet_1_present
+      subnet: 10.10.99.1/24
+      state: query
+    register: nm_query_missing
+    ignore_errors: true
+
+  - name: Query a missing schema in check mode
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *mso_info
+      schema: MissingSchema
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      subnet: 10.10.4.1/24
+      state: query
+    check_mode: true
+    register: cm_missing_schema
+    ignore_errors: true
+
+  - name: Query a missing template in check mode
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: MissingTemplate
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      subnet: 10.10.4.1/24
+      state: query
+    check_mode: true
+    register: cm_missing_template
+    ignore_errors: true
+
+  - name: Query a missing ANP in check mode
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: MissingANP
+      epg: '{{ mso_test.epg }}'
+      subnet: 10.10.4.1/24
+      state: query
+    check_mode: true
+    register: cm_missing_anp
+    ignore_errors: true
+
+  - name: Query a missing EPG in check mode
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: MissingEPG
+      subnet: 10.10.4.1/24
+      state: query
+    check_mode: true
+    register: cm_missing_epg
+    ignore_errors: true
+
+  - name: Reject an invalid subnet scope in check mode
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      subnet: 10.10.4.1/24
+      scope: invalid
+    check_mode: true
+    register: cm_invalid_scope
+    ignore_errors: true
+
+  - name: Reject a missing subnet in check mode
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      state: present
+    check_mode: true
+    register: cm_missing_subnet
+    ignore_errors: true
+
+  - name: Reject an absent subnet without subnet in check mode
+    cisco.mso.mso_schema_template_anp_epg_subnet:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      state: absent
+    check_mode: true
+    register: cm_missing_subnet_absent
+    ignore_errors: true
+
+  - name: Verify error-handling scenarios
+    ansible.builtin.assert:
+      that:
+      - cm_query_missing is failed
+      - nm_query_missing is failed
+      - cm_query_missing.msg is search("Subnet '10.10.99.1/24' not found")
+      - nm_query_missing.msg is search("Subnet '10.10.99.1/24' not found")
+      - cm_missing_schema is failed
+      - cm_missing_schema.msg is search("Provided schema 'MissingSchema' does not exist")
+      - cm_missing_template is failed
+      - cm_missing_template.msg is search("Provided template 'MissingTemplate' does not exist")
+      - cm_missing_anp is failed
+      - cm_missing_anp.msg is search("Provided anp 'MissingANP' does not exist")
+      - cm_missing_epg is failed
+      - cm_missing_epg.msg is search("Provided epg 'MissingEPG' does not exist")
+      - cm_invalid_scope is failed
+      - cm_invalid_scope.msg is search('value of scope must be one of')
+      - cm_missing_subnet is failed
+      - "cm_missing_subnet.msg is search('state is present but all of the following are missing: subnet')"
+      - cm_missing_subnet_absent is failed
+      - "cm_missing_subnet_absent.msg is search('state is absent but all of the following are missing: subnet')"
+
+  always:
+  # CLEANUP
+  - name: Remove test schema even when a test fails
+    cisco.mso.mso_schema:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      state: absent


### PR DESCRIPTION
DCNE-894

## Integration test coverage

The following integration-test targets were added and passed on all supported environments:

| Test target | ND/NDO version | IP | Result |
|---|---|---|---|
| `mso_schema_template_anp_epg_subnet` | ND 3.2 / NDO 4.4 | `10.15.0.127` | Passed |
| `mso_schema_template_anp_epg_subnet` | ND 4.1 / NDO 5.1 | `10.15.0.126` | Passed |
| `mso_schema_template_anp_epg_subnet` | ND 4.2 / NDO 5.2 | `10.15.0.128` | Passed |
| `mso_schema_site_anp_epg_subnet` | ND 3.2 / NDO 4.4 | `10.15.0.127` | Passed |
| `mso_schema_site_anp_epg_subnet` | ND 4.1 / NDO 5.1 | `10.15.0.126` | Passed |
| `mso_schema_site_anp_epg_subnet` | ND 4.2 / NDO 5.2 | `10.15.0.128` | Passed |

## Coverage

The `No site associated with template ...` error path is not exercised because the
site/template association is a prerequisite for the lifecycle under test. The
test therefore establishes that association during setup and focuses error
coverage on invalid sites, invalid site/template combinations, missing schema,
ANP, EPG, subnet, and argument validation.