### PR TITLE
[bugfix] Fix query-all for ndo_match_rule_community_term and ndo_match_rule_prefix modules (DCNE-848, DCNE-849)

### DIFF
--- a/plugins/module_utils/template.py
+++ b/plugins/module_utils/template.py
@@ -880,17 +880,18 @@ class MSOTemplate:
                  When the child object identifiers are None, and the search list is not empty -> List[Dict]
                  When the child object identifiers ae None, and the search list is empty -> List[]
         """
-        if isinstance(identifiers, dict) and identifiers.values():  # Query a specific object
-            for key, value in identifiers.items():
-                if value:
-                    child_object_kvpair = KVPair(key, value)
+        existing_objects = parent_object.details.get(endpoint, [])
+        if isinstance(identifiers, dict):
+            child_object_kvpairs = [KVPair(key, value) for key, value in identifiers.items() if value is not None]
+            if not child_object_kvpairs:
+                return existing_objects  # Query all objects
             return self.get_object_by_key_value_pairs(
                 description,
-                parent_object.details.get(endpoint, []),
-                [child_object_kvpair],
+                existing_objects,
+                child_object_kvpairs,
                 fail_module,
             )
-        return parent_object.details.get(endpoint, [])  # Query all objects
+        return existing_objects  # Query all objects
 
     def get_template_policy_uuid(self, template_type, policy_name, policy_type):
         """


### PR DESCRIPTION
DCNE-848
DCNE-849

The following integration-test targets were run and passed on all supported environments:

Test target | ND/NDO version | IP | Result
-- | -- | -- | --
ndo_match_rule_community_term | ND 3.2 / NDO 4.4 | 10.15.0.127 | Skipped
ndo_match_rule_community_term | ND 4.1 / NDO 5.1 | 10.15.0.126 | Passed
ndo_match_rule_community_term | ND 4.2 / NDO 5.2 | 10.15.0.128 | Passed
ndo_match_rule_prefix | ND 3.2 / NDO 4.4 | 10.15.0.127 | Skipped
ndo_match_rule_prefix | ND 4.1 / NDO 5.1 | 10.15.0.126 | Passed
ndo_match_rule_prefix | ND 4.2 / NDO 5.2 | 10.15.0.128 | Passed
