### PR TITLE
[ignore] fix ndo_tenant_igmp_interface_policy tests to avoid new multcast entries validation rule (DCNE-851)

### DIFF
--- a/tests/integration/targets/ndo_tenant_igmp_interface_policy/tasks/main.yml
+++ b/tests/integration/targets/ndo_tenant_igmp_interface_policy/tasks/main.yml
@@ -381,6 +381,7 @@
         <<: *ansible_igmp_interface_policy_2_updated
         state_limit_route_map_uuid: ""
         static_report_route_map: {}
+        reserved_multicast_entries: 0
         state: present
       register: updated_route_map
 
@@ -499,7 +500,7 @@
           - cm_delete_igmp_interface_policy.previous.querierTimeout == nm_delete_igmp_interface_policy.previous.querierTimeout == 701
           - cm_delete_igmp_interface_policy.previous.queryInterval == nm_delete_igmp_interface_policy.previous.queryInterval == 151
           - cm_delete_igmp_interface_policy.previous.queryResponseInterval == nm_delete_igmp_interface_policy.previous.queryResponseInterval == 21
-          - cm_delete_igmp_interface_policy.previous.reservedMulticastEntries == nm_delete_igmp_interface_policy.previous.reservedMulticastEntries == 86354345
+          - cm_delete_igmp_interface_policy.previous.reservedMulticastEntries == nm_delete_igmp_interface_policy.previous.reservedMulticastEntries == 0
           - cm_delete_igmp_interface_policy.previous.robustnessFactor == nm_delete_igmp_interface_policy.previous.robustnessFactor == 7
           - cm_delete_igmp_interface_policy.previous.startQueryCount == nm_delete_igmp_interface_policy.previous.startQueryCount == 3
           - cm_delete_igmp_interface_policy.previous.startQueryInterval == nm_delete_igmp_interface_policy.previous.startQueryInterval == 1001


### PR DESCRIPTION
DCNE-851

New validation rule got introduced in ND 4.2 which fails test. Updated the config input to comply to this rule.

Invalid configuration for IGMP Interface Policy  ansible_igmp_interface_policy_2_updated: IGMP interface policy 'ansible_igmp_interface_policy_2_updated' has reserved multicast entries but no statelimit route map 
policy reference configured. Statelimit route map policy multicast reference is required when using reserved multicast entries