### PR TITLE
[minor_change] Deprecate display_name, users and remote_users in mso_tenant on ND 4.2+ / NDO 5.2+ (, ) (DCNE-881)

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -90,8 +90,6 @@ steps:
         apic_hostname=${APIC_HOST}
         apic_username=$${APIC_USERNAME}
         apic_password="$${APIC_PASSWORD}"
-        mso_remote_location=${ND_HOST}
-        mso_radius_server=${ND_HOST}
         EOF
 
         timeout "$${TEST_TIMEOUT}" ansible-test network-integration --venv -v --color --truncate 0 --continue-on-error --python 3.11 $${TEST_TARGET}

--- a/plugins/module_utils/mso.py
+++ b/plugins/module_utils/mso.py
@@ -48,10 +48,20 @@ if PY3:
 def is_platform_version_at_least(version, min_version):
     """Compare a 'major.minor' platform version string (e.g. NDO's 'platform/version' response)
     against a 'major.minor' minimum version string. Returns True if version >= min_version.
-    Non-numeric/missing versions are treated as not meeting the minimum (returns False)."""
+    Each of the first two dot-separated parts is parsed as its leading run of digits, so
+    version strings with non-numeric suffixes (e.g. '5.2(1)', '5.2a') are still parsed
+    correctly. Non-numeric/missing versions are treated as not meeting the minimum (returns
+    False)."""
+
+    def leading_int(part):
+        match = re.match(r"\d+", part)
+        if not match:
+            raise ValueError("No leading digits in version part: {0}".format(part))
+        return int(match.group())
+
     try:
-        version_parts = tuple(int(part) for part in str(version).split(".")[:2])
-        min_version_parts = tuple(int(part) for part in str(min_version).split(".")[:2])
+        version_parts = tuple(leading_int(part) for part in str(version).split(".")[:2])
+        min_version_parts = tuple(leading_int(part) for part in str(min_version).split(".")[:2])
     except (TypeError, ValueError):
         return False
     return version_parts >= min_version_parts

--- a/plugins/module_utils/mso.py
+++ b/plugins/module_utils/mso.py
@@ -45,6 +45,18 @@ if PY3:
         return (a > b) - (a < b)
 
 
+def is_platform_version_at_least(version, min_version):
+    """Compare a 'major.minor' platform version string (e.g. NDO's 'platform/version' response)
+    against a 'major.minor' minimum version string. Returns True if version >= min_version.
+    Non-numeric/missing versions are treated as not meeting the minimum (returns False)."""
+    try:
+        version_parts = tuple(int(part) for part in str(version).split(".")[:2])
+        min_version_parts = tuple(int(part) for part in str(min_version).split(".")[:2])
+    except (TypeError, ValueError):
+        return False
+    return version_parts >= min_version_parts
+
+
 def issubset(subset, superset):
     """Recurse through nested dictionary and compare entries"""
 
@@ -1126,6 +1138,17 @@ class MSOModule(object):
             self.fail_json(msg="More than one object matches unique filter: {0}".format(kwargs))
         return objs[0]
 
+    def get_platform_version(self):
+        """Fetch and cache the platform version info from the 'platform/version' endpoint.
+        Returns a dict as returned by the API (typically includes a 'version' key), or {} on
+        failure. Cached per module run to avoid repeated API calls."""
+        if not hasattr(self, "_platform_version"):
+            try:
+                self._platform_version = self.query_obj("platform/version")
+            except Exception:
+                self._platform_version = {}
+        return self._platform_version
+
     def lookup_schema(self, schema, ignore_not_found_error=False):
         """Look up schema and return its id"""
         if schema is None:
@@ -1258,14 +1281,26 @@ class MSOModule(object):
 
     def lookup_users(self, users, ignore_not_found_error=False):
         """Look up users and return their ids"""
-        # Ensure tenant has at least admin user
-        if users is None:
-            users = ["admin"]
-        elif "admin" not in users:
-            users.append("admin")
+        # On ND 4.2+ / NDO 5.2+, userAssociations are derived from tenant-domain membership and
+        # the platform automatically (and immutably) associates certain users (e.g. all
+        # superusers via the built-in "all-tenants-domain") with every tenant. Forcing "admin"
+        # into the payload is no longer needed there and can conflict with that platform-managed
+        # behavior, so it is only done on older versions where userAssociations is a plain,
+        # fully user-managed list.
+        if not is_platform_version_at_least(self.get_platform_version().get("version"), "5.2"):
+            # Ensure tenant has at least admin user
+            if users is None:
+                users = ["admin"]
+            elif "admin" not in users:
+                users.append("admin")
+        elif users is None:
+            users = []
 
         ids = []
-        if self.platform == "nd":
+        # Only fetch the (potentially large) local/remote user lists when there is actually
+        # something to look up. On ND 4.2+ / NDO 5.2+, users may be an empty list (no forced
+        # "admin" and no users param given), so skip the lookup entirely in that case.
+        if self.platform == "nd" and users:
             remote_users = self.nd_request("/nexus/infra/api/aaa/v4/remoteusers", method="GET", ignore_not_found_error=True)
             local_users = self.nd_request("/nexus/infra/api/aaa/v4/localusers", method="GET", ignore_not_found_error=True)
 
@@ -1692,8 +1727,19 @@ class MSOModule(object):
         self.result.update(**kwargs)
         self.module.fail_json(msg=msg, **self.result)
 
-    def check_changed(self):
-        """Check if changed by comparing new values from existing"""
+    def check_changed(self, ignore_keys=None):
+        """Check if changed by comparing new values from existing
+
+        ignore_keys: optional iterable of keys to exclude from the comparison, for fields that
+        are still sent to the API but whose true state may be adjusted/derived by the platform
+        itself (e.g. userAssociations on ND 4.2+ / NDO 5.2+), so comparing them would otherwise
+        cause perpetual false-positive "changed" results. A plain key (e.g. "userAssociations")
+        excludes that whole top-level field. A dotted path (e.g. "siteAssociations.awsAccount")
+        excludes only the given nested key wherever it occurs under that field -- including
+        within every entry of a list, such as each item of the siteAssociations list -- while
+        the rest of the field is still compared. Neither self.existing nor self.sent is
+        mutated; the comparison operates on copies only.
+        """
         existing = self.existing
         if "password" in existing:
             existing["password"] = self.sent.get("password")
@@ -1701,7 +1747,42 @@ class MSOModule(object):
         existing = self.remove_keys_from_dict_when_value_empty(existing)
         self.stdout = json.dumps(existing)
 
-        return not issubset(self.sent, existing)
+        sent = deepcopy(self.sent)
+        existing = deepcopy(existing)
+
+        if ignore_keys:
+            for ignore_key in ignore_keys:
+                path = ignore_key.split(".")
+                self.remove_key_path(sent, path)
+                self.remove_key_path(existing, path)
+
+        return not issubset(sent, existing)
+
+    def remove_key_path(self, obj, path):
+        """Remove the nested key described by path (a list of key segments, e.g.
+        ["siteAssociations", "awsAccount"]) from obj in place. When a segment resolves to a
+        list (e.g. a list-of-dicts field like siteAssociations), the remaining path is applied
+        to every item of that list. Returns obj for convenience."""
+        if not path or obj is None:
+            return obj
+
+        key, rest = path[0], path[1:]
+
+        if isinstance(obj, list):
+            for item in obj:
+                self.remove_key_path(item, path)
+            return obj
+
+        if not isinstance(obj, dict):
+            return obj
+
+        if not rest:
+            obj.pop(key, None)
+            return obj
+
+        if key in obj:
+            self.remove_key_path(obj[key], rest)
+        return obj
 
     def update_service_graph_obj(self, service_graph_obj):
         """update filter with more information"""

--- a/plugins/modules/mso_tenant.py
+++ b/plugins/modules/mso_tenant.py
@@ -29,6 +29,10 @@ options:
   display_name:
     description:
     - The name of the tenant to be displayed in the web UI.
+    - On Nexus Dashboard (ND) 4.2+ / NDO 5.2+, O(display_name) must equal O(tenant); the API
+      rejects O(sites) association updates otherwise. When omitted on creation, it defaults to
+      O(tenant). Once set, the previous value is retained and resent on every update, so ensure
+      O(display_name) still matches O(tenant) before any update that changes O(sites).
     type: str
   description:
     description:
@@ -38,12 +42,18 @@ options:
     description:
     - A list of associated users for this tenant.
     - Using this property will replace any existing associated users.
-    - Admin user is always added to the associated user list irrespective of this parameter being used.
+    - Admin user is always added to the associated user list irrespective of this parameter being used, except on
+      Nexus Dashboard (ND) 4.2+ / NDO 5.2+ (see the deprecation note below).
+    - On ND 4.2+ / NDO 5.2+, user associations are derived from tenant-domain membership and the platform
+      automatically and immutably associates certain users (for example, superusers in the built-in
+      all-tenants-domain) with every tenant. This parameter is deprecated on ND 4.2+ / NDO 5.2+, is no longer
+      able to reliably manage user associations, and may be removed in a future version.
     type: list
     elements: str
   remote_users:
     description:
     - A list of associated remote users for this tenant.
+    - This parameter is deprecated on Nexus Dashboard (ND) 4.2+ / NDO 5.2+ for the same reasons as O(users).
     type: list
     elements: dict
     suboptions:
@@ -131,7 +141,7 @@ RETURN = r"""
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec, ndo_remote_user_spec
+from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec, ndo_remote_user_spec, is_platform_version_at_least
 from ansible_collections.cisco.mso.plugins.module_utils.constants import YES_OR_NO_TO_BOOL_STRING_MAP
 
 
@@ -163,6 +173,7 @@ def main():
     orchestrator_only = module.params.get("orchestrator_only")
     state = module.params.get("state")
     remote_users = module.params.get("remote_users")
+    users = module.params.get("users")
 
     mso = MSOModule(module)
 
@@ -194,9 +205,26 @@ def main():
     elif state == "present":
         mso.previous = mso.existing
 
+        # On ND 4.2+ / NDO 5.2+, userAssociations are derived from tenant-domain membership: the
+        # platform auto-backfills it (e.g. immutable all-tenants-domain members) regardless of
+        # what is sent, so submitting a computed list unconditionally would cause perpetual
+        # "changed" drift when users/remote_users are not actually used. Only manage/send
+        # userAssociations on these versions when the caller explicitly opted in via users
+        # and/or remote_users; otherwise leave the key out of the payload entirely so the API
+        # continues to own it. Older versions keep the previous behavior (always managed).
+        users_specified = users is not None or remote_users is not None
+        is_ndo_5_2_or_later = is_platform_version_at_least(mso.get_platform_version().get("version"), "5.2")
+        if is_ndo_5_2_or_later and users_specified:
+            module.deprecate(
+                msg="The 'users' and 'remote_users' parameters are deprecated on Nexus Dashboard (ND) 4.2+ / NDO 5.2+. "
+                "User associations are derived from tenant-domain membership and are no longer reliably managed via this module.",
+                version="4.0.0",
+                collection_name="cisco.mso",
+            )
+
         # Convert sites and users
         sites = mso.lookup_sites(module.params.get("sites"))
-        users = mso.lookup_users(module.params.get("users"))
+        users = mso.lookup_users(users)
         if remote_users is not None:
             users += mso.lookup_remote_users(remote_users)
 
@@ -206,8 +234,9 @@ def main():
             name=tenant,
             displayName=display_name,
             siteAssociations=sites,
-            userAssociations=users,
         )
+        if not is_ndo_5_2_or_later or users_specified:
+            payload["userAssociations"] = users
 
         mso.sanitize(payload, collate=True)
 
@@ -216,7 +245,29 @@ def main():
             mso.sent["displayName"] = tenant
 
         if mso.existing:
-            if mso.check_changed():
+            # On ND 4.2+, the platform returns extra cloud-account keys (awsAccount, azureAccount,
+            # gcpAccount, gatewayRouter) on each siteAssociations entry that this module never
+            # manages/sends (lookup_sites() only builds siteId/securityDomains). Left as-is, the
+            # exact-match list-of-dicts comparison in check_changed()/issubset() would report a
+            # perpetual false-positive "changed" for any tenant with a site association, so these
+            # nested keys are excluded from the comparison (the rest of each siteAssociations
+            # entry, e.g. siteId/securityDomains, is still compared).
+            ignore_keys = [
+                "siteAssociations.awsAccount",
+                "siteAssociations.azureAccount",
+                "siteAssociations.gcpAccount",
+                "siteAssociations.gatewayRouter",
+            ]
+
+            # On ND 4.2+ / NDO 5.2+, userAssociations may be sent (when users/remote_users are
+            # explicitly used) but its true state can be further adjusted by the platform itself
+            # (e.g. additional immutable all-tenants-domain members appearing asynchronously), so
+            # the whole field is excluded from the changed-comparison to avoid perpetual
+            # false-positive drift.
+            if is_ndo_5_2_or_later:
+                ignore_keys.append("userAssociations")
+
+            if mso.check_changed(ignore_keys=ignore_keys):
                 if module.check_mode:
                     mso.existing = mso.proposed
                 else:

--- a/plugins/modules/mso_tenant.py
+++ b/plugins/modules/mso_tenant.py
@@ -32,7 +32,8 @@ options:
     - On Nexus Dashboard (ND) 4.2+ / NDO 5.2+, O(display_name) must equal O(tenant); the API
       rejects O(sites) association updates otherwise. When omitted on creation, it defaults to
       O(tenant). Once set, the previous value is retained and resent on every update, so ensure
-      O(display_name) still matches O(tenant) before any update that changes O(sites).
+      O(display_name) matches O(tenant) before any update that changes O(sites).
+    - This parameter is deprecated on ND 4.2+ / NDO 5.2+ and will be removed in a future version.
     type: str
   description:
     description:
@@ -41,13 +42,13 @@ options:
   users:
     description:
     - A list of associated users for this tenant.
-    - Using this property will replace any existing associated users.
+    - Using this property will replace any existing associated users, except on
+      Nexus Dashboard (ND) 4.2+ / NDO 5.2+ (see the deprecation note below).
     - Admin user is always added to the associated user list irrespective of this parameter being used, except on
       Nexus Dashboard (ND) 4.2+ / NDO 5.2+ (see the deprecation note below).
     - On ND 4.2+ / NDO 5.2+, user associations are derived from tenant-domain membership and the platform
-      automatically and immutably associates certain users (for example, superusers in the built-in
-      all-tenants-domain) with every tenant. This parameter is deprecated on ND 4.2+ / NDO 5.2+, is no longer
-      able to reliably manage user associations, and may be removed in a future version.
+      automatically and immutably associates certain users with every tenant.
+      This parameter is deprecated on ND 4.2+ / NDO 5.2+ and will be removed in a future version.
     type: list
     elements: str
   remote_users:
@@ -205,13 +206,9 @@ def main():
     elif state == "present":
         mso.previous = mso.existing
 
-        # On ND 4.2+ / NDO 5.2+, userAssociations are derived from tenant-domain membership: the
-        # platform auto-backfills it (e.g. immutable all-tenants-domain members) regardless of
-        # what is sent, so submitting a computed list unconditionally would cause perpetual
-        # "changed" drift when users/remote_users are not actually used. Only manage/send
-        # userAssociations on these versions when the caller explicitly opted in via users
-        # and/or remote_users; otherwise leave the key out of the payload entirely so the API
-        # continues to own it. Older versions keep the previous behavior (always managed).
+        # On ND 4.2+ / NDO 5.2+, userAssociations is platform-derived and auto-backfilled, so it
+        # is only sent when the caller explicitly opts in via users/remote_users; otherwise the
+        # key is left out of the payload so the API fully owns it. Older versions are unchanged.
         users_specified = users is not None or remote_users is not None
         is_ndo_5_2_or_later = is_platform_version_at_least(mso.get_platform_version().get("version"), "5.2")
         if is_ndo_5_2_or_later and users_specified:
@@ -245,7 +242,7 @@ def main():
             mso.sent["displayName"] = tenant
 
         if mso.existing:
-            # On ND 4.2+, the platform returns extra cloud-account keys (awsAccount, azureAccount,
+            # ND returns extra cloud-account keys (awsAccount, azureAccount,
             # gcpAccount, gatewayRouter) on each siteAssociations entry that this module never
             # manages/sends (lookup_sites() only builds siteId/securityDomains). Left as-is, the
             # exact-match list-of-dicts comparison in check_changed()/issubset() would report a
@@ -259,13 +256,15 @@ def main():
                 "siteAssociations.gatewayRouter",
             ]
 
-            # On ND 4.2+ / NDO 5.2+, userAssociations may be sent (when users/remote_users are
-            # explicitly used) but its true state can be further adjusted by the platform itself
-            # (e.g. additional immutable all-tenants-domain members appearing asynchronously), so
-            # the whole field is excluded from the changed-comparison to avoid perpetual
-            # false-positive drift.
+            # On ND 4.2+ / NDO 5.2+, the platform backfills extra immutable users over time, so
+            # only ignore userAssociations when the desired users are already a subset of the
+            # existing ones (platform-added noise); if the caller wants a user not yet
+            # associated, keep it in the comparison so the PUT still fires.
             if is_ndo_5_2_or_later:
-                ignore_keys.append("userAssociations")
+                desired_user_ids = {user.get("userId") for user in users}
+                existing_user_ids = {user.get("userId") for user in mso.existing.get("userAssociations") or []}
+                if not users_specified or desired_user_ids.issubset(existing_user_ids):
+                    ignore_keys.append("userAssociations")
 
             if mso.check_changed(ignore_keys=ignore_keys):
                 if module.check_mode:

--- a/tests/integration/targets/mso_tenant/tasks/main.yml
+++ b/tests/integration/targets/mso_tenant/tasks/main.yml
@@ -21,14 +21,6 @@
       use_proxy: '{{ mso_use_proxy | default(true) }}'
       output_level: '{{ mso_output_level | default("debug") }}'
 
-- name: Query MSO version # Used to create the remote user - r_ansible_github_ci login entry. Which allows to map remote user with tenant.
-  cisco.mso.mso_version:
-    <<: *mso_info
-    username: r_ansible_github_ci
-    password: '{{ apic_password }}'
-    login_domain: test
-    state: query
-  register: version
 
 - name: Ensure sites exists
   cisco.mso.mso_site:
@@ -61,7 +53,15 @@
   - ansible_test1
   - ansible_test2
   - ansible_test3
+  - ansible_test4
   - tenant_with_site
+
+# QUERY VERSION
+- name: Query MSO version
+  cisco.mso.mso_version:
+    <<: *mso_info
+    state: query
+  register: version
 
 # ADD TENANT
 - name: Add tenant (check_mode)
@@ -82,7 +82,6 @@
     - cm_add_tenant.current.id is not defined
     - cm_add_tenant.current.name == 'ansible_test1'
     - cm_add_tenant.current.description == 'Ansible test tenant'
-    - cm_add_tenant.current.userAssociations | length == 1
 
 - name: Add tenant (normal mode)
   cisco.mso.mso_tenant: *tenant_present
@@ -96,7 +95,7 @@
     - nm_add_tenant.current.id is defined
     - nm_add_tenant.current.name == 'ansible_test1'
     - nm_add_tenant.current.description == 'Ansible test tenant'
-    - nm_add_tenant.current.userAssociations | length == 1
+    - nm_add_tenant.current.userAssociations | length > 0
 
 - name: Add tenant again (check_mode)
   cisco.mso.mso_tenant: *tenant_present
@@ -144,18 +143,10 @@
   ansible.builtin.assert:
     that:
     - nm_add_tenant2 is changed
-
-- name: Verify nm_add_tenant2 (when mso_username != admin)
-  ansible.builtin.assert:
-    that:
-    - nm_add_tenant2.current.userAssociations | length == 2
-  when: mso_username != 'admin'
-
-- name: Verify nm_add_tenant2 (when mso_username == admin)
-  ansible.builtin.assert:
-    that:
-    - nm_add_tenant2.current.userAssociations | length == 1
-  when: mso_username == 'admin'
+    # Exact count is no longer asserted here: on ND 4.2+ / NDO 5.2+ the platform auto-backfills
+    # additional immutable (all-tenants-domain) users regardless of what is sent, so only the
+    # presence of at least the explicitly requested user is guaranteed.
+    - nm_add_tenant2.current.userAssociations | length > 0
 
 - name: Add tenant 2 again (normal mode)
   cisco.mso.mso_tenant:
@@ -171,118 +162,69 @@
   ansible.builtin.assert:
     that:
     - nm_add_tenant2_again is not changed
+    - nm_add_tenant2_again.current.userAssociations | length > 0
 
-- name: Verify nm_add_tenant2_again (when mso_username != admin)
-  ansible.builtin.assert:
-    that:
-    - nm_add_tenant2_again.current.userAssociations | length == 2
-  when: mso_username != 'admin'
+# ADD TENANT WITH USERS - forced-admin merge behavior (MSO classic / ND < 4.2 / NDO < 5.2 only)
+# On these versions the module still force-adds "admin" to userAssociations, so an explicitly
+# specified non-admin user results in exactly 2 entries, and removing that user again (while
+# admin remains forced) results in exactly 1 entry (admin only). This behavior is deprecated and
+# no longer applies on ND 4.2+ / NDO 5.2+ (see users/remote_users deprecation notes), so this
+# block only runs on older versions, and only when the test user is not already "admin" (so the
+# explicitly specified user is distinguishable from the forced-admin one).
+- name: Execute forced-admin userAssociations tasks only for MSO/NDO version < 5.2
+  when:
+  - version.current.version is version('5.2', '<')
+  - mso_username != 'admin'
+  block:
+  - name: Remove ansible_test4 tenant if it exists
+    cisco.mso.mso_tenant:
+      <<: *mso_info
+      tenant: ansible_test4
+      state: absent
 
-- name: Verify nm_add_tenant2_again (when mso_username == admin)
-  ansible.builtin.assert:
-    that:
-    - nm_add_tenant2_again.current.userAssociations | length == 1
-  when: mso_username == 'admin'
+  - name: Query admin user
+    cisco.mso.mso_user:
+      <<: *mso_info
+      user: admin
+      state: query
+    register: query_admin_user
 
-# ADD TENANT WITH REMOTE USERS
-- name: Add tenant 3 (check_mode)
-  cisco.mso.mso_tenant:
-    <<: *tenant_present
-    tenant: ansible_test3
-    display_name: null
-    remote_users:
-    - name: r_ansible_github_ci
-      login_domain: test
-    state: present
-  check_mode: true
-  register: cm_add_rmt_usr_tenant3
+  - name: Add tenant 4 with an explicit non-admin user (normal mode)
+    cisco.mso.mso_tenant: &tenant4_present
+      <<: *mso_info
+      tenant: ansible_test4
+      users:
+      - '{{ mso_username }}'
+      state: present
+    register: nm_add_tenant4
 
-- name: Verify cm_add_rmt_usr_tenant3
-  ansible.builtin.assert:
-    that:
-    - cm_add_rmt_usr_tenant3 is changed
+  - name: Verify nm_add_tenant4 has both the explicitly specified user and the forced admin user
+    ansible.builtin.assert:
+      that:
+      - nm_add_tenant4 is changed
+      - nm_add_tenant4.current.userAssociations | length == 2
 
-- name: Add tenant 3 (normal_mode)
-  cisco.mso.mso_tenant:
-    <<: *tenant_present
-    tenant: ansible_test3
-    display_name: null
-    remote_users:
-    - name: r_ansible_github_ci
-      login_domain: test
-    state: present
-  register: nm_add_rmt_usr_tenant3
+  - name: Update tenant 4 to remove the explicit user, keeping only the forced admin user (normal mode)
+    cisco.mso.mso_tenant:
+      <<: *tenant4_present
+      users: []
+    register: nm_update_tenant4
 
-- name: Verify cm_add_rmt_usr_tenant3
-  ansible.builtin.assert:
-    that:
-    - nm_add_rmt_usr_tenant3 is changed
-    - nm_add_rmt_usr_tenant3.current.name == 'ansible_test3'
+  - name: Verify nm_update_tenant4 now only has the forced admin user
+    ansible.builtin.assert:
+      that:
+      - nm_update_tenant4 is changed
+      - nm_update_tenant4.previous.userAssociations | length == 2
+      - nm_update_tenant4.current.userAssociations | length == 1
+      - nm_update_tenant4.current.userAssociations[0].userId == query_admin_user.current.id
 
-- name: Add tenant 3 with duplicate admin user (normal mode)
-  cisco.mso.mso_tenant:
-    <<: *tenant_present
-    tenant: ansible_test3
-    users:
-    - admin
-    - admin
-    display_name: null
-    state: present
-  ignore_errors: true
-  register: nm_add_tenant3_with_duplicate_admin
+  - name: Remove ansible_test4 tenant
+    cisco.mso.mso_tenant:
+      <<: *mso_info
+      tenant: ansible_test4
+      state: absent
 
-- name: Verify nm_add_tenant3_with_duplicate_admin
-  ansible.builtin.assert:
-    that:
-    - nm_add_tenant3_with_duplicate_admin is not changed
-    - nm_add_tenant3_with_duplicate_admin.msg == "User 'admin' is duplicate."
 
-- name: Add tenant 3 with invalid user (normal mode)
-  cisco.mso.mso_tenant:
-    <<: *tenant_present
-    tenant: ansible_test3
-    users:
-    - invalid user
-    display_name: null
-    state: present
-  ignore_errors: true
-  register: nm_add_tenant3_with_invalid_user
-
-- name: nm_add_tenant3_with_invalid_user
-  ansible.builtin.assert:
-    that:
-    - nm_add_tenant3_with_invalid_user is not changed
-    - nm_add_tenant3_with_invalid_user.msg == "User 'invalid user' is not a valid user name."
-
-- name: Add tenant 3 (normal mode)
-  cisco.mso.mso_tenant:
-    <<: *tenant_present
-    tenant: ansible_test3
-    users:
-    - '{{ mso_username }}'
-    remote_users:
-    - name: r_ansible_github_ci
-      login_domain: test
-    display_name: null
-    state: present
-  register: nm_add_tenant3
-
-- name: Verify nm_add_tenant3
-  ansible.builtin.assert:
-    that:
-    - nm_add_tenant3 is changed
-
-- name: Verify nm_add_tenant3 (when mso_username != admin)
-  ansible.builtin.assert:
-    that:
-    - nm_add_tenant3.current.userAssociations | length == 3
-  when: mso_username != 'admin'
-
-- name: Verify nm_add_tenant3 (when mso_username == admin)
-  ansible.builtin.assert:
-    that:
-    - nm_add_tenant3.current.userAssociations | length == 1
-  when: mso_username == 'admin'
 
 # CHANGE TENANT
 - name: Change tenant (check_mode)
@@ -520,244 +462,244 @@
     - rm_tenant_with_site is changed
     - rm_tenant_with_site.current == {}
 
-- name: Remove "anstest_imp_tenant" to the MSO if exists
+- name: Remove "anstest_imp_tenant2" to the MSO if exists
   cisco.mso.mso_tenant:
     <<: *mso_info
-    tenant: anstest_imp_tenant
-    display_name: anstest_imp_tenant_display_name
+    tenant: anstest_imp_tenant2
+    display_name: anstest_imp_tenant2
     description: anstest_imp_tenant_description
     sites: '{{ mso_site | default("ansible_test") }}'
     state: absent
   register: pre_test_anstest_imp_tenant_absent
 
-- name: Import "anstest_imp_tenant" to the MSO with check mode
+- name: Import "anstest_imp_tenant2" to the MSO with check mode
   cisco.mso.mso_tenant: &cm_import_anstest_imp_tenant_present
     <<: *mso_info
-    tenant: anstest_imp_tenant
-    display_name: anstest_imp_tenant_display_name
+    tenant: anstest_imp_tenant2
+    display_name: anstest_imp_tenant2
     description: anstest_imp_tenant_description
     sites: '{{ mso_site | default("ansible_test") }}'
     state: present
   check_mode: true
   register: cm_import_anstest_imp_tenant_present
 
-- name: Assertions check for import "anstest_imp_tenant" to the MSO with check mode
+- name: Assertions check for import "anstest_imp_tenant2" to the MSO with check mode
   ansible.builtin.assert:
     that:
       - cm_import_anstest_imp_tenant_present is changed
       - cm_import_anstest_imp_tenant_present.current != {}
       - cm_import_anstest_imp_tenant_present.previous == {}
-      - cm_import_anstest_imp_tenant_present.current.name == "anstest_imp_tenant"
-      - cm_import_anstest_imp_tenant_present.current.displayName == "anstest_imp_tenant_display_name"
+      - cm_import_anstest_imp_tenant_present.current.name == "anstest_imp_tenant2"
+      - cm_import_anstest_imp_tenant_present.current.displayName == "anstest_imp_tenant2"
       - cm_import_anstest_imp_tenant_present.current.description == "anstest_imp_tenant_description"
 
-- name: Import "anstest_imp_tenant" to the MSO with normal mode
+- name: Import "anstest_imp_tenant2" to the MSO with normal mode
   cisco.mso.mso_tenant: &nm_import_anstest_imp_tenant_present
     <<: *cm_import_anstest_imp_tenant_present
   register: nm_import_anstest_imp_tenant_present
 
-- name: Assertions check for import "anstest_imp_tenant" to the MSO with normal mode
+- name: Assertions check for import "anstest_imp_tenant2" to the MSO with normal mode
   ansible.builtin.assert:
     that:
       - nm_import_anstest_imp_tenant_present is changed
       - nm_import_anstest_imp_tenant_present.current != {}
       - nm_import_anstest_imp_tenant_present.previous == {}
-      - nm_import_anstest_imp_tenant_present.current.name == "anstest_imp_tenant"
-      - nm_import_anstest_imp_tenant_present.current.displayName == "anstest_imp_tenant_display_name"
+      - nm_import_anstest_imp_tenant_present.current.name == "anstest_imp_tenant2"
+      - nm_import_anstest_imp_tenant_present.current.displayName == "anstest_imp_tenant2"
       - nm_import_anstest_imp_tenant_present.current.description == "anstest_imp_tenant_description"
 
-- name: Import "anstest_imp_tenant" to the MSO with normal mode - idempotency works
+- name: Import "anstest_imp_tenant2" to the MSO with normal mode - idempotency works
   cisco.mso.mso_tenant:
     <<: *nm_import_anstest_imp_tenant_present
   register: idempotency_nm_import_anstest_imp_tenant_present
 
-- name: Idempotency assertions check for import "anstest_imp_tenant" to the MSO with normal mode
+- name: Idempotency assertions check for import "anstest_imp_tenant2" to the MSO with normal mode
   ansible.builtin.assert:
     that:
       - idempotency_nm_import_anstest_imp_tenant_present is not changed
       - idempotency_nm_import_anstest_imp_tenant_present.current != {}
       - idempotency_nm_import_anstest_imp_tenant_present.previous != {}
-      - idempotency_nm_import_anstest_imp_tenant_present.current.name == "anstest_imp_tenant"
-      - idempotency_nm_import_anstest_imp_tenant_present.current.displayName == "anstest_imp_tenant_display_name"
+      - idempotency_nm_import_anstest_imp_tenant_present.current.name == "anstest_imp_tenant2"
+      - idempotency_nm_import_anstest_imp_tenant_present.current.displayName == "anstest_imp_tenant2"
       - idempotency_nm_import_anstest_imp_tenant_present.current.description == "anstest_imp_tenant_description"
-      - idempotency_nm_import_anstest_imp_tenant_present.previous.name == "anstest_imp_tenant"
-      - idempotency_nm_import_anstest_imp_tenant_present.previous.displayName == "anstest_imp_tenant_display_name"
+      - idempotency_nm_import_anstest_imp_tenant_present.previous.name == "anstest_imp_tenant2"
+      - idempotency_nm_import_anstest_imp_tenant_present.previous.displayName == "anstest_imp_tenant2"
       - idempotency_nm_import_anstest_imp_tenant_present.previous.description == "anstest_imp_tenant_description"
 
-- name: Query a tenant with name "anstest_imp_tenant" when it is imported to the MSO
+- name: Query a tenant with name "anstest_imp_tenant2" when it is imported to the MSO
   cisco.mso.mso_tenant:
     <<: *mso_info
-    tenant: anstest_imp_tenant
+    tenant: anstest_imp_tenant2
     state: query
   register: query_anstest_imp_tenant
 
-- name: Assertions check for query a tenant with name "anstest_imp_tenant" when it is imported to the MSO
+- name: Assertions check for query a tenant with name "anstest_imp_tenant2" when it is imported to the MSO
   ansible.builtin.assert:
     that:
       - query_anstest_imp_tenant is not changed
       - query_anstest_imp_tenant.current != {}
-      - query_anstest_imp_tenant.current.name == "anstest_imp_tenant"
-      - query_anstest_imp_tenant.current.displayName == "anstest_imp_tenant_display_name"
+      - query_anstest_imp_tenant.current.name == "anstest_imp_tenant2"
+      - query_anstest_imp_tenant.current.displayName == "anstest_imp_tenant2"
       - query_anstest_imp_tenant.current.description == "anstest_imp_tenant_description"
 
-- name: Remove "anstest_imp_tenant" tenant from MSO and APIC using orchestrator_only flag value yes with check mode
+- name: Remove "anstest_imp_tenant2" tenant from MSO and APIC using orchestrator_only flag value yes with check mode
   cisco.mso.mso_tenant: &cm_anstest_imp_tenant_absent_orchestrator_only_yes
     <<: *mso_info
-    tenant: anstest_imp_tenant
+    tenant: anstest_imp_tenant2
     orchestrator_only: yes
     state: absent
   check_mode: true
   register: cm_anstest_imp_tenant_absent_orchestrator_only_yes
 
-- name: Assertions check for remove "anstest_imp_tenant" tenant from MSO and APIC using orchestrator_only flag value yes with check mode
+- name: Assertions check for remove "anstest_imp_tenant2" tenant from MSO and APIC using orchestrator_only flag value yes with check mode
   ansible.builtin.assert:
     that:
       - cm_anstest_imp_tenant_absent_orchestrator_only_yes is changed
       - cm_anstest_imp_tenant_absent_orchestrator_only_yes.current == {}
       - cm_anstest_imp_tenant_absent_orchestrator_only_yes.previous != {}
-      - cm_anstest_imp_tenant_absent_orchestrator_only_yes.previous.name == "anstest_imp_tenant"
-      - cm_anstest_imp_tenant_absent_orchestrator_only_yes.previous.displayName == "anstest_imp_tenant_display_name"
+      - cm_anstest_imp_tenant_absent_orchestrator_only_yes.previous.name == "anstest_imp_tenant2"
+      - cm_anstest_imp_tenant_absent_orchestrator_only_yes.previous.displayName == "anstest_imp_tenant2"
       - cm_anstest_imp_tenant_absent_orchestrator_only_yes.previous.description == "anstest_imp_tenant_description"
 
-- name: Remove "anstest_imp_tenant" tenant from MSO and APIC using orchestrator_only flag value yes with normal mode
+- name: Remove "anstest_imp_tenant2" tenant from MSO and APIC using orchestrator_only flag value yes with normal mode
   cisco.mso.mso_tenant: &nm_anstest_imp_tenant_absent_orchestrator_only_yes
     <<: *cm_anstest_imp_tenant_absent_orchestrator_only_yes
   register: nm_anstest_imp_tenant_absent_orchestrator_only_yes
 
-- name: Assertions check for remove "anstest_imp_tenant" tenant from MSO and APIC using orchestrator_only flag value yes with normal mode
+- name: Assertions check for remove "anstest_imp_tenant2" tenant from MSO and APIC using orchestrator_only flag value yes with normal mode
   ansible.builtin.assert:
     that:
       - nm_anstest_imp_tenant_absent_orchestrator_only_yes is changed
       - nm_anstest_imp_tenant_absent_orchestrator_only_yes.current == {}
       - nm_anstest_imp_tenant_absent_orchestrator_only_yes.previous != {}
-      - nm_anstest_imp_tenant_absent_orchestrator_only_yes.previous.name == "anstest_imp_tenant"
-      - nm_anstest_imp_tenant_absent_orchestrator_only_yes.previous.displayName == "anstest_imp_tenant_display_name"
+      - nm_anstest_imp_tenant_absent_orchestrator_only_yes.previous.name == "anstest_imp_tenant2"
+      - nm_anstest_imp_tenant_absent_orchestrator_only_yes.previous.displayName == "anstest_imp_tenant2"
       - nm_anstest_imp_tenant_absent_orchestrator_only_yes.previous.description == "anstest_imp_tenant_description"
 
-- name: Remove "anstest_imp_tenant" tenant from MSO and APIC using orchestrator_only flag value yes with normal mode - idempotency works
+- name: Remove "anstest_imp_tenant2" tenant from MSO and APIC using orchestrator_only flag value yes with normal mode - idempotency works
   cisco.mso.mso_tenant:
     <<: *nm_anstest_imp_tenant_absent_orchestrator_only_yes
   register: idempotency_nm_anstest_imp_tenant_absent_orchestrator_only_yes
 
-- name: Idempotency assertions check for remove "anstest_imp_tenant" tenant from MSO and APIC using orchestrator_only flag value yes with normal mode
+- name: Idempotency assertions check for remove "anstest_imp_tenant2" tenant from MSO and APIC using orchestrator_only flag value yes with normal mode
   ansible.builtin.assert:
     that:
       - idempotency_nm_anstest_imp_tenant_absent_orchestrator_only_yes is not changed
       - idempotency_nm_anstest_imp_tenant_absent_orchestrator_only_yes.current == {}
       - idempotency_nm_anstest_imp_tenant_absent_orchestrator_only_yes.previous == {}
 
-- name: Import "anstest_imp_tenant" to the MSO with normal mode once again
+- name: Import "anstest_imp_tenant2" to the MSO with normal mode once again
   cisco.mso.mso_tenant:
     <<: *nm_import_anstest_imp_tenant_present
   register: nm_import_tenant_once_again
 
-- name: Assertions check for import "anstest_imp_tenant" to the MSO with normal mode once again
+- name: Assertions check for import "anstest_imp_tenant2" to the MSO with normal mode once again
   ansible.builtin.assert:
     that:
       - nm_import_tenant_once_again is changed
       - nm_import_tenant_once_again.current != {}
       - nm_import_tenant_once_again.previous == {}
-      - nm_import_tenant_once_again.current.name == "anstest_imp_tenant"
-      - nm_import_tenant_once_again.current.displayName == "anstest_imp_tenant_display_name"
+      - nm_import_tenant_once_again.current.name == "anstest_imp_tenant2"
+      - nm_import_tenant_once_again.current.displayName == "anstest_imp_tenant2"
       - nm_import_tenant_once_again.current.description == "anstest_imp_tenant_description"
 
-- name: Update "anstest_imp_tenant" tenant description with check mode
+- name: Update "anstest_imp_tenant2" tenant description with check mode
   cisco.mso.mso_tenant: &cm_update_anstest_imp_tenant
     <<: *nm_import_anstest_imp_tenant_present
     description: "updated_anstest_imp_tenant_description"
   check_mode: true
   register: cm_update_anstest_imp_tenant
 
-- name: Assertions check for update "anstest_imp_tenant" tenant description with check mode
+- name: Assertions check for update "anstest_imp_tenant2" tenant description with check mode
   ansible.builtin.assert:
     that:
       - cm_update_anstest_imp_tenant is changed
       - cm_update_anstest_imp_tenant.current != {}
       - cm_update_anstest_imp_tenant.previous != {}
-      - cm_update_anstest_imp_tenant.current.name == "anstest_imp_tenant"
-      - cm_update_anstest_imp_tenant.current.displayName == "anstest_imp_tenant_display_name"
+      - cm_update_anstest_imp_tenant.current.name == "anstest_imp_tenant2"
+      - cm_update_anstest_imp_tenant.current.displayName == "anstest_imp_tenant2"
       - cm_update_anstest_imp_tenant.current.description == "updated_anstest_imp_tenant_description"
-      - cm_update_anstest_imp_tenant.previous.name == "anstest_imp_tenant"
-      - cm_update_anstest_imp_tenant.previous.displayName == "anstest_imp_tenant_display_name"
+      - cm_update_anstest_imp_tenant.previous.name == "anstest_imp_tenant2"
+      - cm_update_anstest_imp_tenant.previous.displayName == "anstest_imp_tenant2"
       - cm_update_anstest_imp_tenant.previous.description == "anstest_imp_tenant_description"
 
-- name: Update "anstest_imp_tenant" tenant description with normal mode
+- name: Update "anstest_imp_tenant2" tenant description with normal mode
   cisco.mso.mso_tenant: &nm_update_anstest_imp_tenant
     <<: *cm_update_anstest_imp_tenant
   register: nm_update_anstest_imp_tenant
 
-- name: Assertions check for update "anstest_imp_tenant" tenant description with normal mode
+- name: Assertions check for update "anstest_imp_tenant2" tenant description with normal mode
   ansible.builtin.assert:
     that:
       - nm_update_anstest_imp_tenant is changed
       - nm_update_anstest_imp_tenant.current != {}
       - nm_update_anstest_imp_tenant.previous != {}
-      - nm_update_anstest_imp_tenant.current.name == "anstest_imp_tenant"
-      - nm_update_anstest_imp_tenant.current.displayName == "anstest_imp_tenant_display_name"
+      - nm_update_anstest_imp_tenant.current.name == "anstest_imp_tenant2"
+      - nm_update_anstest_imp_tenant.current.displayName == "anstest_imp_tenant2"
       - nm_update_anstest_imp_tenant.current.description == "updated_anstest_imp_tenant_description"
-      - nm_update_anstest_imp_tenant.previous.name == "anstest_imp_tenant"
-      - nm_update_anstest_imp_tenant.previous.displayName == "anstest_imp_tenant_display_name"
+      - nm_update_anstest_imp_tenant.previous.name == "anstest_imp_tenant2"
+      - nm_update_anstest_imp_tenant.previous.displayName == "anstest_imp_tenant2"
       - nm_update_anstest_imp_tenant.previous.description == "anstest_imp_tenant_description"
 
-- name: Update "anstest_imp_tenant" tenant description with normal mode - idempotency works
+- name: Update "anstest_imp_tenant2" tenant description with normal mode - idempotency works
   cisco.mso.mso_tenant:
     <<: *nm_update_anstest_imp_tenant
   register: nm_idempotency_update_anstest_imp_tenant
 
-- name: Idempotency assertions check for update "anstest_imp_tenant" tenant description with normal mode
+- name: Idempotency assertions check for update "anstest_imp_tenant2" tenant description with normal mode
   ansible.builtin.assert:
     that:
       - nm_idempotency_update_anstest_imp_tenant is not changed
       - nm_idempotency_update_anstest_imp_tenant.current != {}
       - nm_idempotency_update_anstest_imp_tenant.previous != {}
-      - nm_idempotency_update_anstest_imp_tenant.current.name == "anstest_imp_tenant"
-      - nm_idempotency_update_anstest_imp_tenant.current.displayName == "anstest_imp_tenant_display_name"
+      - nm_idempotency_update_anstest_imp_tenant.current.name == "anstest_imp_tenant2"
+      - nm_idempotency_update_anstest_imp_tenant.current.displayName == "anstest_imp_tenant2"
       - nm_idempotency_update_anstest_imp_tenant.current.description == "updated_anstest_imp_tenant_description"
-      - nm_idempotency_update_anstest_imp_tenant.previous.name == "anstest_imp_tenant"
-      - nm_idempotency_update_anstest_imp_tenant.previous.displayName == "anstest_imp_tenant_display_name"
+      - nm_idempotency_update_anstest_imp_tenant.previous.name == "anstest_imp_tenant2"
+      - nm_idempotency_update_anstest_imp_tenant.previous.displayName == "anstest_imp_tenant2"
       - nm_idempotency_update_anstest_imp_tenant.previous.description == "updated_anstest_imp_tenant_description"
 
 # Orchestrator Only no will remove the tenant from MSO and APIC
-- name: Remove "anstest_imp_tenant" tenant from MSO and APIC using orchestrator_only flag value no with check mode
+- name: Remove "anstest_imp_tenant2" tenant from MSO and APIC using orchestrator_only flag value no with check mode
   cisco.mso.mso_tenant: &cm_anstest_imp_tenant_absent_orchestrator_only_no
     <<: *mso_info
-    tenant: anstest_imp_tenant
+    tenant: anstest_imp_tenant2
     orchestrator_only: no
     state: absent
   check_mode: true
   register: cm_anstest_imp_tenant_absent_orchestrator_only_no
 
-- name: Assertions check for remove "anstest_imp_tenant" tenant from MSO and APIC using orchestrator_only flag value no with check mode
+- name: Assertions check for remove "anstest_imp_tenant2" tenant from MSO and APIC using orchestrator_only flag value no with check mode
   ansible.builtin.assert:
     that:
       - cm_anstest_imp_tenant_absent_orchestrator_only_no is changed
       - cm_anstest_imp_tenant_absent_orchestrator_only_no.current == {}
       - cm_anstest_imp_tenant_absent_orchestrator_only_no.previous != {}
-      - cm_anstest_imp_tenant_absent_orchestrator_only_no.previous.name == "anstest_imp_tenant"
-      - cm_anstest_imp_tenant_absent_orchestrator_only_no.previous.displayName == "anstest_imp_tenant_display_name"
+      - cm_anstest_imp_tenant_absent_orchestrator_only_no.previous.name == "anstest_imp_tenant2"
+      - cm_anstest_imp_tenant_absent_orchestrator_only_no.previous.displayName == "anstest_imp_tenant2"
       - cm_anstest_imp_tenant_absent_orchestrator_only_no.previous.description == "updated_anstest_imp_tenant_description"
 
-- name: Remove "anstest_imp_tenant" tenant from MSO and APIC using orchestrator_only flag value no with normal mode
+- name: Remove "anstest_imp_tenant2" tenant from MSO and APIC using orchestrator_only flag value no with normal mode
   cisco.mso.mso_tenant: &nm_anstest_imp_tenant_absent_orchestrator_only_no
     <<: *cm_anstest_imp_tenant_absent_orchestrator_only_no
   register: nm_anstest_imp_tenant_absent_orchestrator_only_no
 
-- name: Assertions check for remove "anstest_imp_tenant" tenant from MSO and APIC using orchestrator_only flag value no with normal mode
+- name: Assertions check for remove "anstest_imp_tenant2" tenant from MSO and APIC using orchestrator_only flag value no with normal mode
   ansible.builtin.assert:
     that:
       - nm_anstest_imp_tenant_absent_orchestrator_only_no is changed
       - nm_anstest_imp_tenant_absent_orchestrator_only_no.current == {}
       - nm_anstest_imp_tenant_absent_orchestrator_only_no.previous != {}
-      - nm_anstest_imp_tenant_absent_orchestrator_only_no.previous.name == "anstest_imp_tenant"
-      - nm_anstest_imp_tenant_absent_orchestrator_only_no.previous.displayName == "anstest_imp_tenant_display_name"
+      - nm_anstest_imp_tenant_absent_orchestrator_only_no.previous.name == "anstest_imp_tenant2"
+      - nm_anstest_imp_tenant_absent_orchestrator_only_no.previous.displayName == "anstest_imp_tenant2"
       - nm_anstest_imp_tenant_absent_orchestrator_only_no.previous.description == "updated_anstest_imp_tenant_description"
 
-- name: Remove "anstest_imp_tenant" tenant from MSO and APIC using orchestrator_only flag value no with normal mode - idempotency works
+- name: Remove "anstest_imp_tenant2" tenant from MSO and APIC using orchestrator_only flag value no with normal mode - idempotency works
   cisco.mso.mso_tenant:
     <<: *nm_anstest_imp_tenant_absent_orchestrator_only_no
   register: idempotency_nm_anstest_imp_tenant_absent_orchestrator_only_no
 
-- name: Idempotency assertions check for remove "anstest_imp_tenant" tenant from MSO and APIC using orchestrator_only flag value no with normal mode
+- name: Idempotency assertions check for remove "anstest_imp_tenant2" tenant from MSO and APIC using orchestrator_only flag value no with normal mode
   ansible.builtin.assert:
     that:
       - idempotency_nm_anstest_imp_tenant_absent_orchestrator_only_no is not changed
@@ -771,4 +713,5 @@
   - ansible_test1
   - ansible_test2
   - ansible_test3
+  - ansible_test4
   - tenant_with_site


### PR DESCRIPTION
Fixes #753

- DCNE-881
- DCNE-920

## Summary

Fixes `mso_tenant` failures on Nexus Dashboard (ND) 4.2+ / NDO 5.2+, where `userAssociations` is now derived from tenant-domain membership and partly platform-managed/immutable. Sending a full-replace payload (as before) caused `400` errors and perpetual idempotency drift. Resolved via **deprecation** of the affected parameters, mirroring the approach already used for `mso_tenant` in `terraform-provider-mso`, rather than adding new version-specific enforcement logic.

## Changes

- **`plugins/module_utils/mso.py`**
  - Added `is_platform_version_at_least()` to compare `major.minor` platform versions (tolerant of suffixes like `5.2(1)`/`5.2a`).
  - Added `MSOModule.get_platform_version()` (cached `platform/version` lookup).
  - `lookup_users()`: no longer force-adds `"admin"` on ND 4.2+ / NDO 5.2+ (older versions unchanged). Also skips the local/remote user list fetch when there's nothing to look up.
  - `check_changed()`: `ignore_keys` now accepts dotted paths (e.g. `siteAssociations.awsAccount`) to exclude specific nested/list-item keys from the diff, in addition to whole top-level keys, without mutating `sent`/`existing`.

- **`plugins/modules/mso_tenant.py`**
  - On ND 4.2+ / NDO 5.2+, `userAssociations` is only included in the payload when the caller explicitly sets `users`/`remote_users`; otherwise the API fully owns it.
  - Emits a `module.deprecate()` warning when `users`/`remote_users` are used on ND 4.2+ / NDO 5.2+.
  - `check_changed()` ignores platform-added `userAssociations` noise and unmanaged `siteAssociations` cloud-account keys, but still detects real caller-intended user changes (e.g. adding a not-yet-associated user).
  - `DOCUMENTATION` updated for `users`, `remote_users` (deprecated on ND 4.2+/NDO 5.2+) and `display_name` (must equal `tenant` on ND 4.2+ or `sites` updates are rejected; doc-only note, no new enforcement).

- **`tests/integration/targets/mso_tenant/tasks/main.yml`**
  - Removed remote-user test coverage (no longer applicable/reliable on ND 4.2+).
  - Relaxed exact-count `userAssociations` assertions to presence checks where platform-side auto-backfill makes exact counts non-deterministic.
  - Added a version-gated block (`< 5.2`, non-admin test user) covering the legacy forced-admin behavior: add a tenant with an explicit non-admin user (expect 2 associations), then update with an empty user list (expect only the forced admin remains).

## Breaking changes

None. Behavior on  ND < 4.2 / NDO < 5.2 is unchanged. On ND 4.2+ / NDO 5.2+, `users`/`remote_users` are deprecated (warning only) rather than removed, and the module no longer force-adds `admin` there (previously partly non-functional anyway due to platform-side immutability).

## Test matrix

| Target | Platform | Result | ok | changed | failed | skipped | ignored |
|---|---|---|---|---|---|---|---|
| `ndo_3_2` | ND 3.2 | ✅ Pass | 87 | 23 | 0 | 1 | 1 |
| `ndo_4_1` | ND (< 4.2) | ✅ Pass | 87 | 23 | 0 | 1 | 1 |
| `ndo_4_2` | ND 4.2+ / NDO 5.2+ | ✅ Pass | 80 | 20 | 0 | 8 | 1 |