### PR TITLE
Add test for mso schema site anp epg staticleaf (DCNE-933)

### DIFF
--- a/plugins/modules/mso_schema_site_anp_epg_staticleaf.py
+++ b/plugins/modules/mso_schema_site_anp_epg_staticleaf.py
@@ -184,7 +184,8 @@ def main():
         mso.fail_json(msg="No site associated with template '{0}'. Associate the site with the template using mso_schema_site.".format(template))
     sites = [(s.get("siteId"), s.get("templateName")) for s in schema_obj.get("sites")]
     if (site_id, template) not in sites:
-        mso.fail_json(msg="Provided site/template '{0}-{1}' does not exist. Existing sites/templates: {2}".format(site, template, ", ".join(sites)))
+        existing_sites_templates = ", ".join("{0}-{1}".format(site_id, template_name) for site_id, template_name in sites)
+        mso.fail_json(msg="Provided site/template '{0}-{1}' does not exist. Existing sites/templates: {2}".format(site, template, existing_sites_templates))
 
     # Schema-access uses indexes
     site_idx = sites.index((site_id, template))

--- a/plugins/modules/mso_schema_site_anp_epg_staticleaf.py
+++ b/plugins/modules/mso_schema_site_anp_epg_staticleaf.py
@@ -85,22 +85,10 @@ EXAMPLES = r"""
     template: Template1
     anp: ANP1
     epg: EPG1
-    leaf: Leaf1
+    pod: pod-1
+    leaf: '101'
     vlan: 123
     state: present
-
-- name: Remove a static leaf from a site EPG
-  cisco.mso.mso_schema_site_anp_epg_staticleaf:
-    host: mso_host
-    username: admin
-    password: SomeSecretPassword
-    schema: Schema1
-    site: Site1
-    template: Template1
-    anp: ANP1
-    epg: EPG1
-    leaf: Leaf1
-    state: absent
 
 - name: Query a specific site EPG static leaf
   cisco.mso.mso_schema_site_anp_epg_staticleaf:
@@ -112,7 +100,9 @@ EXAMPLES = r"""
     template: Template1
     anp: ANP1
     epg: EPG1
-    leaf: Leaf1
+    pod: pod-1
+    leaf: '101'
+    vlan: 123
     state: query
   register: query_result
 
@@ -125,8 +115,24 @@ EXAMPLES = r"""
     site: Site1
     template: Template1
     anp: ANP1
+    epg: EPG1
     state: query
   register: query_result
+
+- name: Remove a static leaf from a site EPG
+  cisco.mso.mso_schema_site_anp_epg_staticleaf:
+    host: mso_host
+    username: admin
+    password: SomeSecretPassword
+    schema: Schema1
+    site: Site1
+    template: Template1
+    anp: ANP1
+    epg: EPG1
+    pod: pod-1
+    leaf: '101'
+    vlan: 123
+    state: absent
 """
 
 RETURN = r"""

--- a/tests/integration/targets/mso_schema_site_anp_epg_staticleaf/aliases
+++ b/tests/integration/targets/mso_schema_site_anp_epg_staticleaf/aliases
@@ -1,0 +1,3 @@
+# The module and integration test are supported.
+# Uncomment the following line to exclude this test target when necessary.
+# unsupported

--- a/tests/integration/targets/mso_schema_site_anp_epg_staticleaf/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_staticleaf/tasks/main.yml
@@ -1,0 +1,480 @@
+---
+# Test code for the MSO modules
+# Copyright: (c) 2026, Cisco Systems, Inc.
+# Copyright: (c) 2026, Akini Ross (@akinross) <akinross@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that required ACI MultiSite variables are defined
+  ansible.builtin.fail:
+    msg: 'Please define mso_hostname, mso_username and mso_password.'
+  when: >-
+    mso_hostname is not defined or
+    mso_username is not defined or
+    mso_password is not defined
+
+- name: Set test connection and fixture variables
+  ansible.builtin.set_fact:
+    mso_info: &mso_info
+      host: '{{ mso_hostname }}'
+      username: '{{ mso_username }}'
+      password: '{{ mso_password }}'
+      validate_certs: '{{ mso_validate_certs | default(false) }}'
+      use_ssl: '{{ mso_use_ssl | default(true) }}'
+      use_proxy: '{{ mso_use_proxy | default(true) }}'
+      output_level: debug
+    mso_test:
+      schema: '{{ mso_schema_site_anp_epg_staticleaf | default(mso_schema | default("ansible_test")) }}'
+      tenant: '{{ mso_tenant_site_anp_epg_staticleaf | default(mso_tenant | default("ansible_test")) }}'
+      site: '{{ mso_site_anp_epg_staticleaf | default(mso_site | default("ansible_test")) }}'
+      template: Template1
+      anp: ANP1
+      epg: EPG1
+      bd: BD1
+      vrf: VRF1
+
+- name: Exercise mso_schema_site_anp_epg_staticleaf
+  block:
+
+  # CLEAN ENVIRONMENT
+  # Due to API changes in ND 4.2, the configured site and tenant are
+  # prerequisites for this test and must already exist. They are intentionally
+  # not created or queried here; only their tenant-site association is managed.
+  - name: Remove test schema before testing
+    cisco.mso.mso_schema:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      state: absent
+
+  - name: Ensure schema and template exist
+    cisco.mso.mso_schema_template:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      tenant: '{{ mso_test.tenant }}'
+      template: '{{ mso_test.template }}'
+
+  # TODO: mso_tenant_site is deprecated. Replace this with the supported
+  # tenant-site association solution, or require a stable test environment
+  # where this association is already present before the test runs.
+  - name: Associate the site with the tenant
+    cisco.mso.mso_tenant_site:
+      <<: *mso_info
+      tenant: '{{ mso_test.tenant }}'
+      site: '{{ mso_test.site }}'
+
+  - name: Associate the site with the schema template
+    cisco.mso.mso_schema_site:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      site: '{{ mso_test.site }}'
+      template: '{{ mso_test.template }}'
+
+  - name: Ensure VRF exists
+    cisco.mso.mso_schema_template_vrf:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      vrf: '{{ mso_test.vrf }}'
+
+  - name: Ensure bridge domain exists
+    cisco.mso.mso_schema_template_bd:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      bd: '{{ mso_test.bd }}'
+      vrf:
+        name: '{{ mso_test.vrf }}'
+
+  - name: Ensure template ANP exists
+    cisco.mso.mso_schema_template_anp:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+
+  - name: Ensure template EPG exists with parent references
+    cisco.mso.mso_schema_template_anp_epg:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      bd:
+        name: '{{ mso_test.bd }}'
+      vrf:
+        name: '{{ mso_test.vrf }}'
+
+  # CREATE
+  - name: Create static leaf 1 in check mode
+    cisco.mso.mso_schema_site_anp_epg_staticleaf: &staticleaf_1_present
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      pod: pod-1
+      leaf: '101'
+      vlan: 126
+    check_mode: true
+    register: cm_create_staticleaf_1
+
+  - name: Create static leaf 1
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *staticleaf_1_present
+    register: nm_create_staticleaf_1
+
+  - name: Create static leaf 1 again
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *staticleaf_1_present
+    register: nm_create_staticleaf_1_again
+
+  - name: Verify static leaf 1 create and idempotency
+    ansible.builtin.assert:
+      that:
+      - cm_create_staticleaf_1 is changed
+      - cm_create_staticleaf_1.previous == {}
+      - cm_create_staticleaf_1.proposed == cm_create_staticleaf_1.current
+      - cm_create_staticleaf_1.current.path == 'topology/pod-1/node-101'
+      - cm_create_staticleaf_1.current.portEncapVlan == 126
+      - nm_create_staticleaf_1 is changed
+      - nm_create_staticleaf_1.previous == {}
+      - nm_create_staticleaf_1.proposed == nm_create_staticleaf_1.current
+      - nm_create_staticleaf_1.current.path == 'topology/pod-1/node-101'
+      - nm_create_staticleaf_1.current.portEncapVlan == 126
+      - nm_create_staticleaf_1_again is not changed
+      - nm_create_staticleaf_1_again.previous.path == nm_create_staticleaf_1.current.path
+      - nm_create_staticleaf_1_again.previous.portEncapVlan == nm_create_staticleaf_1.current.portEncapVlan
+      - nm_create_staticleaf_1_again.proposed.path == nm_create_staticleaf_1.current.path
+      - nm_create_staticleaf_1_again.proposed.portEncapVlan == nm_create_staticleaf_1.current.portEncapVlan
+      - nm_create_staticleaf_1_again.current.path == nm_create_staticleaf_1.current.path
+      - nm_create_staticleaf_1_again.current.portEncapVlan == nm_create_staticleaf_1.current.portEncapVlan
+
+  - name: Create static leaf 2 with the leaf alias and omitted state
+    cisco.mso.mso_schema_site_anp_epg_staticleaf: &staticleaf_2_present
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      pod: pod-2
+      name: '102'
+      vlan: 100
+    check_mode: true
+    register: cm_create_staticleaf_2
+
+  - name: Create static leaf 2 with the default state
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *staticleaf_2_present
+    register: nm_create_staticleaf_2
+
+  - name: Create static leaf 2 again
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *staticleaf_2_present
+    register: nm_create_staticleaf_2_again
+
+  - name: Verify static leaf 2 alias, default state, and idempotency
+    ansible.builtin.assert:
+      that:
+      - cm_create_staticleaf_2 is changed
+      - cm_create_staticleaf_2.current.path == 'topology/pod-2/node-102'
+      - cm_create_staticleaf_2.current.portEncapVlan == 100
+      - nm_create_staticleaf_2 is changed
+      - nm_create_staticleaf_2.current.path == 'topology/pod-2/node-102'
+      - nm_create_staticleaf_2.current.portEncapVlan == 100
+      - nm_create_staticleaf_2_again is not changed
+      - nm_create_staticleaf_2_again.current.path == nm_create_staticleaf_2.current.path
+      - nm_create_staticleaf_2_again.current.portEncapVlan == nm_create_staticleaf_2.current.portEncapVlan
+
+  # UPDATE
+  # The module identifies a static leaf by the combined path
+  # (topology/<pod>/node-<leaf>) and portEncapVlan. These are all of the
+  # module's managed attributes, so changing the VLAN or path does not update
+  # the existing object; it creates a distinct static leaf instead. There is
+  # therefore no meaningful update scenario for this module.
+
+  # QUERY
+  - name: Query static leaf 1 in check mode
+    cisco.mso.mso_schema_site_anp_epg_staticleaf: &staticleaf_1_query
+      <<: *staticleaf_1_present
+      state: query
+    check_mode: true
+    register: cm_query_staticleaf_1
+
+  - name: Query static leaf 1
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *staticleaf_1_query
+    register: nm_query_staticleaf_1
+
+  - name: Create static leaf 3 for query-all coverage
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      pod: pod-3
+      leaf: '103'
+      vlan: 101
+
+  - name: Query all site EPG static leafs in check mode
+    cisco.mso.mso_schema_site_anp_epg_staticleaf: &all_staticleafs_query
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      state: query
+    check_mode: true
+    register: cm_query_all_staticleafs
+
+  - name: Query all site EPG static leafs
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *all_staticleafs_query
+    register: nm_query_all_staticleafs
+
+  - name: Verify individual static leaf query
+    ansible.builtin.assert:
+      that:
+      - cm_query_staticleaf_1 is not changed
+      - nm_query_staticleaf_1 is not changed
+      - cm_query_staticleaf_1.current == nm_query_staticleaf_1.current == nm_create_staticleaf_1_again.current
+      # Query results may contain controller-generated fields that are not
+      # present in the initial create result. The idempotent repeat provides
+      # the stable controller-object response shape used for this comparison.
+      - cm_query_staticleaf_1.current.path == nm_query_staticleaf_1.current.path == 'topology/pod-1/node-101'
+      - cm_query_staticleaf_1.current.portEncapVlan == nm_query_staticleaf_1.current.portEncapVlan == 126
+
+  - name: Verify static leaf collection query
+    ansible.builtin.assert:
+      that:
+      - cm_query_all_staticleafs is not changed
+      - nm_query_all_staticleafs is not changed
+      - cm_query_all_staticleafs.current == nm_query_all_staticleafs.current
+      - cm_query_all_staticleafs.current | length == nm_query_all_staticleafs.current | length == 3
+      - cm_query_all_staticleafs.current | selectattr('path', 'equalto', 'topology/pod-1/node-101') | list | length == 1
+      - cm_query_all_staticleafs.current | selectattr('portEncapVlan', 'equalto', 126) | list | length == 1
+      - cm_query_all_staticleafs.current | selectattr('path', 'equalto', 'topology/pod-2/node-102') | list | length == 1
+      - cm_query_all_staticleafs.current | selectattr('portEncapVlan', 'equalto', 100) | list | length == 1
+      - cm_query_all_staticleafs.current | selectattr('path', 'equalto', 'topology/pod-3/node-103') | list | length == 1
+      - cm_query_all_staticleafs.current | selectattr('portEncapVlan', 'equalto', 101) | list | length == 1
+
+  # DELETE
+  - name: Delete static leaf 1 in check mode
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *staticleaf_1_present
+      state: absent
+    check_mode: true
+    register: cm_delete_staticleaf_1
+
+  - name: Delete static leaf 1
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *staticleaf_1_present
+      state: absent
+    register: nm_delete_staticleaf_1
+
+  - name: Delete static leaf 1 again
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *staticleaf_1_present
+      state: absent
+    register: nm_delete_staticleaf_1_again
+
+  - name: Verify static leaf 1 delete, absence, and idempotency
+    ansible.builtin.assert:
+      that:
+      - cm_delete_staticleaf_1 is changed
+      - cm_delete_staticleaf_1.previous == nm_create_staticleaf_1_again.current
+      - cm_delete_staticleaf_1.previous.path == nm_create_staticleaf_1_again.current.path == 'topology/pod-1/node-101'
+      - cm_delete_staticleaf_1.previous.portEncapVlan == nm_create_staticleaf_1_again.current.portEncapVlan == 126
+      - cm_delete_staticleaf_1.proposed == cm_delete_staticleaf_1.current == {}
+      - nm_delete_staticleaf_1 is changed
+      - nm_delete_staticleaf_1.previous == nm_create_staticleaf_1_again.current
+      - nm_delete_staticleaf_1.previous.path == nm_create_staticleaf_1_again.current.path == 'topology/pod-1/node-101'
+      - nm_delete_staticleaf_1.previous.portEncapVlan == nm_create_staticleaf_1_again.current.portEncapVlan == 126
+      - nm_delete_staticleaf_1.proposed == nm_delete_staticleaf_1.current == {}
+      - nm_delete_staticleaf_1_again is not changed
+      - nm_delete_staticleaf_1_again.previous == nm_delete_staticleaf_1_again.proposed == nm_delete_staticleaf_1_again.current == {}
+
+  # ERROR HANDLING
+  - name: Query nonexistent static leaf in check mode
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *staticleaf_1_present
+      leaf: '999'
+      vlan: 999
+      state: query
+    check_mode: true
+    register: cm_query_missing
+    ignore_errors: true
+
+  - name: Query a missing schema in check mode
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: MissingSchema
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      pod: pod-1
+      leaf: '101'
+      vlan: 126
+      state: query
+    check_mode: true
+    register: cm_missing_schema
+    ignore_errors: true
+
+  - name: Query a missing site in check mode
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *mso_info
+      site: MissingSite
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      pod: pod-1
+      leaf: '101'
+      vlan: 126
+      state: query
+    check_mode: true
+    register: cm_missing_site
+    ignore_errors: true
+
+  - name: Query a missing template in check mode
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: MissingTemplate
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      pod: pod-1
+      leaf: '101'
+      vlan: 126
+      state: query
+    check_mode: true
+    register: cm_missing_template
+    ignore_errors: true
+
+  - name: Query a missing ANP in check mode
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: MissingANP
+      epg: '{{ mso_test.epg }}'
+      pod: pod-1
+      leaf: '101'
+      vlan: 126
+      state: query
+    check_mode: true
+    register: cm_missing_anp
+    ignore_errors: true
+
+  - name: Query a missing EPG in check mode
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: MissingEPG
+      pod: pod-1
+      leaf: '101'
+      vlan: 126
+      state: query
+    check_mode: true
+    register: cm_missing_epg
+    ignore_errors: true
+
+  - name: Reject a missing pod in check mode
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      leaf: '101'
+      vlan: 126
+      state: present
+    check_mode: true
+    register: cm_missing_pod
+    ignore_errors: true
+
+  - name: Reject a missing leaf in check mode
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      pod: pod-1
+      vlan: 126
+      state: present
+    check_mode: true
+    register: cm_missing_leaf
+    ignore_errors: true
+
+  - name: Reject a missing VLAN in check mode
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      pod: pod-1
+      leaf: '101'
+      state: present
+    check_mode: true
+    register: cm_missing_vlan
+    ignore_errors: true
+
+  - name: Reject an absent static leaf without its required attributes in check mode
+    cisco.mso.mso_schema_site_anp_epg_staticleaf:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      anp: '{{ mso_test.anp }}'
+      epg: '{{ mso_test.epg }}'
+      state: absent
+    check_mode: true
+    register: cm_missing_absent_attributes
+    ignore_errors: true
+
+  - name: Verify error-handling scenarios
+    ansible.builtin.assert:
+      that:
+      - cm_query_missing is failed
+      - cm_query_missing.msg is search("Static leaf '999/999' not found")
+      - cm_missing_schema is failed
+      - cm_missing_schema.msg is search("Provided schema 'MissingSchema' does not exist")
+      - cm_missing_site is failed
+      - cm_missing_site.msg is search("Site 'MissingSite' is not a valid site name")
+      - cm_missing_template is failed
+      - "cm_missing_template.msg is search(\"Provided site/template '\" ~ mso_test.site ~ \"-MissingTemplate' does not exist\")"
+      - cm_missing_anp is failed
+      - cm_missing_anp.msg is search("Provided anp 'MissingANP' does not exist")
+      - cm_missing_epg is failed
+      - cm_missing_epg.msg is search("Provided epg 'MissingEPG' does not exist")
+      - cm_missing_pod is failed
+      - "cm_missing_pod.msg is search('state is present but all of the following are missing: pod')"
+      - cm_missing_leaf is failed
+      - "cm_missing_leaf.msg is search('state is present but all of the following are missing: leaf')"
+      - cm_missing_vlan is failed
+      - "cm_missing_vlan.msg is search('state is present but all of the following are missing: vlan')"
+      - cm_missing_absent_attributes is failed
+      - "cm_missing_absent_attributes.msg is search('state is absent but all of the following are missing: pod, leaf, vlan')"
+
+  always:
+  # CLEANUP
+  - name: Remove test schema even when a test fails
+    cisco.mso.mso_schema:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      state: absent

--- a/tests/integration/targets/mso_schema_site_anp_epg_subnet/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_subnet/tasks/main.yml
@@ -37,7 +37,7 @@
   # CLEAN ENVIRONMENT
   # Due to API changes in ND 4.2, the configured site and tenant are
   # prerequisites for this test and must already exist. They are intentionally
-  # not created or queried here.
+  # not created or queried here; only their tenant-site association is managed.
   - name: Remove test schema before testing
     cisco.mso.mso_schema:
       <<: *mso_info
@@ -50,6 +50,15 @@
       schema: '{{ mso_test.schema }}'
       tenant: '{{ mso_test.tenant }}'
       template: '{{ mso_test.template }}'
+
+  # TODO: mso_tenant_site is deprecated. Replace this with the supported
+  # tenant-site association solution, or require a stable test environment
+  # where this association is already present before the test runs.
+  - name: Associate the site with the tenant
+    cisco.mso.mso_tenant_site:
+      <<: *mso_info
+      tenant: '{{ mso_test.tenant }}'
+      site: '{{ mso_test.site }}'
 
   - name: Associate the site with the schema template
     cisco.mso.mso_schema_site:

--- a/tests/integration/targets/mso_schema_site_anp_epg_subnet/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_anp_epg_subnet/tasks/main.yml
@@ -102,23 +102,6 @@
       vrf:
         name: '{{ mso_test.vrf }}'
 
-  - name: Ensure site ANP exists
-    cisco.mso.mso_schema_site_anp:
-      <<: *mso_info
-      site: '{{ mso_test.site }}'
-      schema: '{{ mso_test.schema }}'
-      template: '{{ mso_test.template }}'
-      anp: '{{ mso_test.anp }}'
-
-  - name: Ensure site EPG exists
-    cisco.mso.mso_schema_site_anp_epg:
-      <<: *mso_info
-      site: '{{ mso_test.site }}'
-      schema: '{{ mso_test.schema }}'
-      template: '{{ mso_test.template }}'
-      anp: '{{ mso_test.anp }}'
-      epg: '{{ mso_test.epg }}'
-
   # CREATE
   - name: Create subnet 1 with all supported attributes in check mode
     cisco.mso.mso_schema_site_anp_epg_subnet: &subnet_1_present


### PR DESCRIPTION
DCNE-933

The fintegration-test targets passed on all supported environments:
Test target | ND/NDO version | IP | Result
-- | -- | -- | --
mso_schema_site_anp_epg_subnet | ND 3.2 / NDO 4.4 | 10.15.0.127 | Passed
mso_schema_site_anp_epg_subnet | ND 4.1 / NDO 5.1 | 10.15.0.126 | Passed
mso_schema_site_anp_epg_subnet | ND 4.2 / NDO 5.2 | 10.15.0.128 | Passed
mso_schema_site_anp_epg_staticleaf | ND 3.2 / NDO 4.4 | 10.15.0.127 | Passed
mso_schema_site_anp_epg_staticleaf | ND 4.1 / NDO 5.1 | 10.15.0.126 | Passed
mso_schema_site_anp_epg_staticleaf | ND 4.2 / NDO 5.2 | 10.15.0.128 | Passed
