### PR TITLE
Bugfix patch child removal mso schema site vrf (DCNE-928, DCNE-934)

### DIFF
--- a/plugins/modules/mso_schema_site_vrf.py
+++ b/plugins/modules/mso_schema_site_vrf.py
@@ -7,7 +7,6 @@
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import copy
 
 ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
 
@@ -106,6 +105,7 @@ RETURN = r"""
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec
 from ansible_collections.cisco.mso.plugins.module_utils.utils import append_update_ops_data
+import copy
 
 
 def main():

--- a/plugins/modules/mso_schema_site_vrf.py
+++ b/plugins/modules/mso_schema_site_vrf.py
@@ -144,7 +144,8 @@ def main():
         mso.fail_json(msg="No site associated with template '{0}'. Associate the site with the template using mso_schema_site.".format(template))
     sites = [(s.get("siteId"), s.get("templateName")) for s in schema_obj.get("sites")]
     if (site_id, template) not in sites:
-        mso.fail_json(msg="Provided site/template '{0}-{1}' does not exist. Existing sites/templates: {2}".format(site, template, ", ".join(sites)))
+        existing_sites_templates = ", ".join("{0}-{1}".format(site_id, template_name) for site_id, template_name in sites)
+        mso.fail_json(msg="Provided site/template '{0}-{1}' does not exist. Existing sites/templates: {2}".format(site, template, existing_sites_templates))
 
     # Schema-access uses indexes
     site_idx = sites.index((site_id, template))
@@ -187,13 +188,13 @@ def main():
         mso.sanitize(payload, collate=True)
 
         if mso.existing:
-            ops.append(dict(op="replace", path=vrf_path, value=mso.sent))
+            append_update_ops_data(ops, copy.deepcopy(mso.previous), vrf_path, payload)
         else:
             ops.append(dict(op="add", path=vrfs_path + "/-", value=mso.sent))
 
         mso.existing = mso.proposed
 
-    if not module.check_mode:
+    if not module.check_mode and ops:
         mso.request(schema_path, method="PATCH", data=ops)
 
     mso.exit_json()

--- a/plugins/modules/mso_schema_site_vrf.py
+++ b/plugins/modules/mso_schema_site_vrf.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
+import copy
 
 ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
 
@@ -104,6 +105,7 @@ RETURN = r"""
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec
+from ansible_collections.cisco.mso.plugins.module_utils.utils import append_update_ops_data
 
 
 def main():
@@ -159,10 +161,15 @@ def main():
         vrf_idx = vrfs.index(vrf_ref)
         vrf_path = "/sites/{0}/vrfs/{1}".format(site_template, vrf)
         mso.existing = schema_obj.get("sites")[site_idx]["vrfs"][vrf_idx]
+        if isinstance(mso.existing.get("vrfRef"), str):
+            mso.existing["vrfRef"] = mso.dict_from_ref(mso.existing["vrfRef"])
 
     if state == "query":
         if vrf is None:
             mso.existing = schema_obj.get("sites")[site_idx]["vrfs"]
+            for site_vrf in mso.existing:
+                if isinstance(site_vrf.get("vrfRef"), str):
+                    site_vrf["vrfRef"] = mso.dict_from_ref(site_vrf["vrfRef"])
         elif not mso.existing:
             mso.fail_json(msg="VRF '{vrf}' not found".format(vrf=vrf))
         mso.exit_json()

--- a/tests/integration/targets/mso_schema_site_vrf/aliases
+++ b/tests/integration/targets/mso_schema_site_vrf/aliases
@@ -1,0 +1,3 @@
+# The module and integration test are supported.
+# Uncomment the following line to exclude this test target when necessary.
+# unsupported

--- a/tests/integration/targets/mso_schema_site_vrf/tasks/main.yml
+++ b/tests/integration/targets/mso_schema_site_vrf/tasks/main.yml
@@ -1,0 +1,337 @@
+---
+# Test code for the MSO modules
+# Copyright: (c) 2026, Cisco Systems, Inc.
+# Copyright: (c) 2026, Akini Ross (@akinross) <akinross@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that required ACI MultiSite variables are defined
+  ansible.builtin.fail:
+    msg: 'Please define mso_hostname, mso_username and mso_password.'
+  when: mso_hostname is not defined or mso_username is not defined or mso_password is not defined
+
+- name: Set test connection and fixture variables
+  ansible.builtin.set_fact:
+    mso_info: &mso_info
+      host: '{{ mso_hostname }}'
+      username: '{{ mso_username }}'
+      password: '{{ mso_password }}'
+      validate_certs: '{{ mso_validate_certs | default(false) }}'
+      use_ssl: '{{ mso_use_ssl | default(true) }}'
+      use_proxy: '{{ mso_use_proxy | default(true) }}'
+      output_level: debug
+    mso_test:
+      schema: '{{ mso_schema_site_vrf | default(mso_schema | default("ansible_test")) }}'
+      tenant: '{{ mso_tenant_site_vrf | default(mso_tenant | default("ansible_test")) }}'
+      site: '{{ mso_site_vrf | default(mso_site | default("ansible_test")) }}'
+      template: Template1
+      vrf: VRF1
+
+- name: Exercise mso_schema_site_vrf
+  block:
+
+  # CLEAN ENVIRONMENT
+  # Due to API changes in ND 4.2, the configured site and tenant are
+  # prerequisites for this test and must already exist. They are intentionally
+  # not created or queried here; only their tenant-site association is managed.
+  - name: Remove test schema before testing
+    cisco.mso.mso_schema:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      state: absent
+
+  - name: Ensure schema and template exist
+    cisco.mso.mso_schema_template:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      tenant: '{{ mso_test.tenant }}'
+      template: '{{ mso_test.template }}'
+
+  - name: Query schema metadata for the update fixture
+    cisco.mso.mso_schema:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      state: query
+    register: nm_update_schema
+
+  # TODO: mso_tenant_site is deprecated. Replace this with the supported
+  # tenant-site association solution, or require a stable test environment
+  # where this association is already present before the test runs.
+  - name: Associate the site with the tenant
+    cisco.mso.mso_tenant_site:
+      <<: *mso_info
+      tenant: '{{ mso_test.tenant }}'
+      site: '{{ mso_test.site }}'
+
+  - name: Associate the site with the schema template
+    cisco.mso.mso_schema_site:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      site: '{{ mso_test.site }}'
+      template: '{{ mso_test.template }}'
+    register: nm_schema_site
+
+  # A site VRF must reference an existing template VRF. ND replicates the
+  # template VRFs to the site when the schema template is associated.
+  - name: Ensure template VRFs exist
+    cisco.mso.mso_schema_template_vrf:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      vrf: '{{ item }}'
+    loop:
+    - '{{ mso_test.vrf }}'
+    - VRF2
+    - VRF3
+
+  # CREATE
+  # Site VRF creation is skipped because ND automatically replicates the
+  # template VRFs to the associated site.
+
+  # UPDATE
+  # The site VRF is replicated automatically from the template. Add a child
+  # object through the REST API, then reconcile the existing parent with the
+  # module and verify that the child object is preserved.
+  # routeTargetAddresses is not exposed by mso_schema_site_vrf yet, so
+  # mso_rest is used to configure this child object for the test.
+  - name: Add route target address to site VRF 1
+    cisco.mso.mso_rest:
+      <<: *mso_info
+      path: "/mso/api/v1/schemas/{{ nm_update_schema.current.id }}"
+      method: patch
+      content:
+      - op: add
+        path: "/sites/{{ nm_schema_site.current.siteId }}-{{ mso_test.template }}/vrfs/{{ mso_test.vrf }}/routeTargetAddresses/-"
+        value:
+          addressFamily: ipv4-ucast
+          address: route-target:as4-nn2:65001:100
+          routeTargetType: export
+
+  - name: Update site VRF 1 in check mode
+    cisco.mso.mso_schema_site_vrf: &site_vrf_1_update
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      name: '{{ mso_test.vrf }}'
+    check_mode: true
+    register: cm_update_site_vrf_1
+
+  - name: Update site VRF 1
+    cisco.mso.mso_schema_site_vrf:
+      <<: *site_vrf_1_update
+    register: nm_update_site_vrf_1
+
+  - name: Update site VRF 1 again
+    cisco.mso.mso_schema_site_vrf:
+      <<: *site_vrf_1_update
+    register: nm_update_site_vrf_1_again
+
+  - name: Verify site VRF 1 update and child preservation
+    ansible.builtin.assert:
+      that:
+      - cm_update_site_vrf_1 is not changed
+      - nm_update_site_vrf_1 is not changed
+      - nm_update_site_vrf_1_again is not changed
+      - cm_update_site_vrf_1.current.vrfRef == nm_update_site_vrf_1.current.vrfRef
+      - nm_update_site_vrf_1.current.vrfRef.vrfName == mso_test.vrf
+      - nm_update_site_vrf_1.current.routeTargetAddresses | length == 1
+      - nm_update_site_vrf_1.current.routeTargetAddresses[0].addressFamily == 'ipv4-ucast'
+      - nm_update_site_vrf_1.current.routeTargetAddresses[0].address == 'route-target:as4-nn2:65001:100'
+      - nm_update_site_vrf_1.current.routeTargetAddresses[0].routeTargetType == 'export'
+      - nm_update_site_vrf_1_again.current.routeTargetAddresses == nm_update_site_vrf_1.current.routeTargetAddresses
+
+  # QUERY
+  - name: Query site VRF 1 in check mode
+    cisco.mso.mso_schema_site_vrf: &site_vrf_1_query
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      vrf: '{{ mso_test.vrf }}'
+      state: query
+    check_mode: true
+    register: cm_query_site_vrf_1
+
+  - name: Query site VRF 1
+    cisco.mso.mso_schema_site_vrf:
+      <<: *site_vrf_1_query
+    register: nm_query_site_vrf_1
+
+  - name: Query all site VRFs in check mode
+    cisco.mso.mso_schema_site_vrf: &all_site_vrfs_query
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      state: query
+    check_mode: true
+    register: cm_query_all_site_vrfs
+
+  - name: Query all site VRFs
+    cisco.mso.mso_schema_site_vrf:
+      <<: *all_site_vrfs_query
+    register: nm_query_all_site_vrfs
+
+  - name: Verify individual site VRF query
+    ansible.builtin.assert:
+      that:
+      - cm_query_site_vrf_1 is not changed
+      - nm_query_site_vrf_1 is not changed
+      - cm_query_site_vrf_1.current.vrfRef == nm_query_site_vrf_1.current.vrfRef
+      - cm_query_site_vrf_1.current.vrfRef.templateName == mso_test.template
+      - cm_query_site_vrf_1.current.vrfRef.vrfName == mso_test.vrf
+      - cm_query_site_vrf_1.current.vrfRef.schemaId is defined
+      - cm_query_site_vrf_1.current.routeTargetAddresses == nm_update_site_vrf_1.current.routeTargetAddresses
+
+  - name: Verify site VRF collection query
+    ansible.builtin.assert:
+      that:
+      - cm_query_all_site_vrfs is not changed
+      - nm_query_all_site_vrfs is not changed
+      - cm_query_all_site_vrfs.current == nm_query_all_site_vrfs.current
+      - cm_query_all_site_vrfs.current | length == nm_query_all_site_vrfs.current | length == 3
+      - cm_query_all_site_vrfs.current | selectattr('vrfRef.vrfName', 'equalto', mso_test.vrf) | list | length == 1
+      - cm_query_all_site_vrfs.current | selectattr('vrfRef.vrfName', 'equalto', 'VRF2') | list | length == 1
+      - cm_query_all_site_vrfs.current | selectattr('vrfRef.vrfName', 'equalto', 'VRF3') | list | length == 1
+
+  # DELETE
+  # Deleting the site VRF removes the explicitly configured site object and
+  # its routeTargetAddresses child. ND may then re-replicate the parent VRF
+  # from the template without preserving the site-level child configuration.
+  - name: Delete site VRF 1 in check mode
+    cisco.mso.mso_schema_site_vrf: &site_vrf_1_absent
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      vrf: '{{ mso_test.vrf }}'
+      state: absent
+    check_mode: true
+    register: cm_delete_site_vrf_1
+
+  - name: Delete site VRF 1
+    cisco.mso.mso_schema_site_vrf:
+      <<: *site_vrf_1_absent
+    register: nm_delete_site_vrf_1
+
+  - name: Delete site VRF 1 again
+    cisco.mso.mso_schema_site_vrf:
+      <<: *site_vrf_1_absent
+    register: nm_delete_site_vrf_1_again
+
+  - name: Verify site VRF 1 delete, absence, and idempotency
+    ansible.builtin.assert:
+      that:
+      - cm_delete_site_vrf_1 is changed
+      - cm_delete_site_vrf_1.previous.vrfRef == nm_update_site_vrf_1.current.vrfRef
+      - cm_delete_site_vrf_1.previous.vrfRef.templateName == mso_test.template
+      - cm_delete_site_vrf_1.previous.vrfRef.vrfName == mso_test.vrf
+      - cm_delete_site_vrf_1.previous.vrfRef.schemaId is defined
+      - cm_delete_site_vrf_1.proposed == cm_delete_site_vrf_1.current == {}
+      # Adding the route-target child makes this site VRF explicitly modified,
+      # so NDO reports the delete as a real change.
+      - nm_delete_site_vrf_1 is changed
+      - nm_delete_site_vrf_1.previous.vrfRef == nm_update_site_vrf_1.current.vrfRef
+      - nm_delete_site_vrf_1.previous.vrfRef.templateName == mso_test.template
+      - nm_delete_site_vrf_1.previous.vrfRef.vrfName == mso_test.vrf
+      - nm_delete_site_vrf_1.previous.vrfRef.schemaId is defined
+      - nm_delete_site_vrf_1.proposed == nm_delete_site_vrf_1.current == {}
+      - nm_delete_site_vrf_1_again is not changed
+      # ND retains or re-replicates the site VRF after the first delete, so a
+      # repeated delete still sees the same managed VRF identity. The child
+      # and controller-generated fields may differ after re-replication.
+      - nm_delete_site_vrf_1_again.previous.vrfRef == nm_delete_site_vrf_1.previous.vrfRef
+      - nm_delete_site_vrf_1_again.proposed == nm_delete_site_vrf_1_again.current == {}
+
+  # ERROR HANDLING
+  - name: Query nonexistent site VRF in check mode
+    cisco.mso.mso_schema_site_vrf:
+      <<: *site_vrf_1_query
+      vrf: MissingVRF
+      state: query
+    check_mode: true
+    register: cm_query_missing
+    ignore_errors: true
+
+  - name: Query a missing schema in check mode
+    cisco.mso.mso_schema_site_vrf:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: MissingSchema
+      template: '{{ mso_test.template }}'
+      vrf: '{{ mso_test.vrf }}'
+      state: query
+    check_mode: true
+    register: cm_missing_schema
+    ignore_errors: true
+
+  - name: Query a missing site in check mode
+    cisco.mso.mso_schema_site_vrf:
+      <<: *mso_info
+      site: MissingSite
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      vrf: '{{ mso_test.vrf }}'
+      state: query
+    check_mode: true
+    register: cm_missing_site
+    ignore_errors: true
+
+  - name: Query a missing template in check mode
+    cisco.mso.mso_schema_site_vrf:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: MissingTemplate
+      vrf: '{{ mso_test.vrf }}'
+      state: query
+    check_mode: true
+    register: cm_missing_template
+    ignore_errors: true
+
+  - name: Reject a missing VRF in check mode
+    cisco.mso.mso_schema_site_vrf:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      state: present
+    check_mode: true
+    register: cm_missing_vrf
+    ignore_errors: true
+
+  - name: Reject an absent site VRF without a VRF in check mode
+    cisco.mso.mso_schema_site_vrf:
+      <<: *mso_info
+      site: '{{ mso_test.site }}'
+      schema: '{{ mso_test.schema }}'
+      template: '{{ mso_test.template }}'
+      state: absent
+    check_mode: true
+    register: cm_missing_vrf_absent
+    ignore_errors: true
+
+  - name: Verify error-handling scenarios
+    ansible.builtin.assert:
+      that:
+      - cm_query_missing is failed
+      - cm_query_missing.msg is search("VRF 'MissingVRF' not found")
+      - cm_missing_schema is failed
+      - cm_missing_schema.msg is search("Provided schema 'MissingSchema' does not exist")
+      - cm_missing_site is failed
+      - cm_missing_site.msg is search("Site 'MissingSite' is not a valid site name")
+      - cm_missing_template is failed
+      - "cm_missing_template.msg is search(\"Provided site/template '\" ~ mso_test.site ~ \"-MissingTemplate' does not exist\")"
+      - cm_missing_vrf is failed
+      - "cm_missing_vrf.msg is search('state is present but all of the following are missing: vrf')"
+      - cm_missing_vrf_absent is failed
+      - "cm_missing_vrf_absent.msg is search('state is absent but all of the following are missing: vrf')"
+
+  always:
+  # CLEANUP
+  - name: Remove test schema even when a test fails
+    cisco.mso.mso_schema:
+      <<: *mso_info
+      schema: '{{ mso_test.schema }}'
+      state: absent


### PR DESCRIPTION
DCNE-928
DCNE-934

The mso_schema_site_vrf integration-test targets passed on all supported environments:

Test target | ND/NDO version | IP | Result
-- | -- | -- | --
mso_schema_site_vrf | ND 3.2 / NDO 4.4 | 10.15.0.127 | Passed
mso_schema_site_vrf | ND 4.1 / NDO 5.1 | 10.15.0.126 | Passed
mso_schema_site_vrf | ND 4.2 / NDO 5.2 | 10.15.0.128 | Passed